### PR TITLE
fix(e2e): add opencode agent image to e2e setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,14 +313,16 @@ e2e-reload: e2e-docker-build e2e-kind-load e2e-verify-image ## Rebuild and reloa
 	@echo "Controller image reloaded successfully"
 .PHONY: e2e-reload
 
-# Build echo agent image for e2e testing
-e2e-agent-build: ## Build echo agent image for e2e testing
+# Build agent images for e2e testing
+e2e-agent-build: ## Build agent images for e2e testing (echo + opencode)
 	docker build -t quay.io/kubeopencode/kubeopencode-agent-echo:latest agents/echo/
+	docker build -t quay.io/kubeopencode/kubeopencode-agent-opencode:latest agents/opencode/
 .PHONY: e2e-agent-build
 
-# Load echo agent image into kind cluster
-e2e-agent-load: ## Load echo agent image into kind cluster
+# Load agent images into kind cluster
+e2e-agent-load: ## Load agent images into kind cluster (echo + opencode)
 	kind load docker-image quay.io/kubeopencode/kubeopencode-agent-echo:latest --name $(E2E_CLUSTER_NAME)
+	kind load docker-image quay.io/kubeopencode/kubeopencode-agent-opencode:latest --name $(E2E_CLUSTER_NAME)
 .PHONY: e2e-agent-load
 
 


### PR DESCRIPTION
## Summary

- Add opencode agent image to E2E test setup to fix failing tests
- The two-container pattern requires `kubeopencode-agent-opencode:latest` for the init container
- Previously only the echo agent was built and loaded, causing ImagePullBackOff errors

## Root Cause

The E2E tests were failing because:
1. The controller always creates an `opencode-init` init container using `DefaultAgentImage`
2. `DefaultAgentImage` defaults to `quay.io/kubeopencode/kubeopencode-agent-opencode:latest`
3. This image was not being built or loaded into the Kind cluster during `e2e-setup`
4. Pods failed with ImagePullBackOff → Tasks entered `Failed` status → Tests timed out

## Changes

- `e2e-agent-build`: Now builds both echo and opencode agent images
- `e2e-agent-load`: Now loads both images into the Kind cluster

## Test plan

- [ ] E2E tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)