### PR TITLE
chore: prepare v0.0.2 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -918,7 +918,7 @@ kubectl logs <pod-name> -n kubeopencode-system
 
 ## Project Status
 
-- **Version**: v0.0.1
+- **Version**: v0.0.2
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 - **Maintainer**: kubeopencode/kubeopencode team

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.1
+VERSION ?= 0.0.2
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.1.60
 IMG_REGISTRY ?= quay.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.1
+VERSION ?= 0.0.2
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.1
-appVersion: "v0.0.1"
+version: 0.0.2
+appVersion: "v0.0.2"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

Prepare the v0.0.2 release by updating version references across the project.

### Key changes since v0.0.1

**Breaking API Change:**
- Remove TaskTemplate CRD to simplify API (#71) — Tasks now use inline configuration only

**New Features:**
- Add `profile` field to Agent for discovery (#61)

**Refactoring:**
- Extract environment helpers to constants.go (#60)
- Simplify Agent status update (#59)
- Consolidate Agent configuration resolution (#58)
- Combine capacity check loops (#56)
- Extract credential builder from buildPod (#57)
- Extract failed status update helper (#55)

**Dependencies:**
- Bump sigs.k8s.io/controller-runtime (#66)
- Bump docker/setup-buildx-action from 3 to 4 (#65)
- Bump docker/setup-qemu-action from 3 to 4 (#64)
- Bump docker/login-action from 3 to 4 (#63)
- Bump docker/build-push-action from 6 to 7 (#67)
- Bump Go dependencies (#52)
- Bump UI dependencies (#53, #68)

**Agents:**
- Bump opencode version to 1.2.22 (#69)
- Upgrade ENVTEST_K8S_VERSION from 1.31.0 to 1.35.0

### Version updates in this PR
- `Makefile`: VERSION 0.0.1 → 0.0.2
- `agents/Makefile`: VERSION 0.0.1 → 0.0.2
- `charts/kubeopencode/Chart.yaml`: version 0.0.2, appVersion v0.0.2
- `CLAUDE.md`: Project status version v0.0.2

## Test plan
- [x] `make verify` — generated code up to date
- [x] `make test` — all unit tests pass
- [x] `make integration-test` — 54/54 pass
- [x] `make lint` — 0 issues
- [x] Version command outputs `kubeopencode version 0.0.2`
- [x] Helm template renders `quay.io/kubeopencode/kubeopencode:v0.0.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)