### PR TITLE
fix(controller): prevent Git context from shadowing workspace when mountPath is root

### DIFF
--- a/cmd/kubeopencode/git_init.go
+++ b/cmd/kubeopencode/git_init.go
@@ -15,15 +15,17 @@ import (
 
 // Environment variable names for git-init
 const (
-	envRepo        = "GIT_REPO"
-	envRef         = "GIT_REF"
-	envDepth       = "GIT_DEPTH"
-	envRoot        = "GIT_ROOT"
-	envLink        = "GIT_LINK"
-	envUsername    = "GIT_USERNAME"
-	envPassword    = "GIT_PASSWORD"
-	envSSHKey      = "GIT_SSH_KEY"
-	envSSHHostKeys = "GIT_SSH_KNOWN_HOSTS"
+	envRepo            = "GIT_REPO"
+	envRef             = "GIT_REF"
+	envDepth           = "GIT_DEPTH"
+	envRoot            = "GIT_ROOT"
+	envLink            = "GIT_LINK"
+	envUsername        = "GIT_USERNAME"
+	envPassword        = "GIT_PASSWORD"
+	envSSHKey          = "GIT_SSH_KEY"
+	envSSHHostKeys     = "GIT_SSH_KNOWN_HOSTS"
+	envGitWorkspaceDir = "GIT_WORKSPACE_DIR"
+	envGitRepoSubpath  = "GIT_REPO_SUBPATH"
 )
 
 // Default values for git-init
@@ -153,6 +155,25 @@ func runGitInit(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Printf("git-init: Clone successful!\n")
 		fmt.Printf("  Commit: %s\n", strings.TrimSpace(string(commitOutput)))
+	}
+
+	// If GIT_WORKSPACE_DIR is set, merge cloned content into the workspace directory.
+	// This is used when a Git context has mountPath equal to workspaceDir (e.g., mountPath: ".").
+	// Instead of overlaying the workspace with a separate volume mount (which would shadow
+	// files like task.md written by context-init), we copy the repo content so both coexist.
+	if wsDir := os.Getenv(envGitWorkspaceDir); wsDir != "" {
+		sourceDir := targetDir
+		if subpath := os.Getenv(envGitRepoSubpath); subpath != "" {
+			sourceDir = filepath.Join(targetDir, subpath)
+		}
+		fmt.Printf("git-init: Merging repository content into workspace %s...\n", wsDir)
+		cpCmd := exec.Command("cp", "-a", sourceDir+"/.", wsDir+"/") //nolint:gosec // paths are from controlled env vars
+		cpCmd.Stdout = os.Stdout
+		cpCmd.Stderr = os.Stderr
+		if err := cpCmd.Run(); err != nil {
+			return fmt.Errorf("failed to merge repository into workspace: %w", err)
+		}
+		fmt.Println("git-init: Repository content merged into workspace successfully")
 	}
 
 	// Clean up credentials file after successful clone

--- a/internal/controller/pod_builder.go
+++ b/internal/controller/pod_builder.go
@@ -5,6 +5,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -702,20 +703,50 @@ func buildPod(task *kubeopenv1alpha1.Task, podName string, agentNamespace string
 			},
 		})
 
-		// Build init container for git clone
-		initContainers = append(initContainers, buildGitInitContainer(gm, volumeName, i, sysCfg))
+		// Check if this git context should be merged into the workspace root.
+		// When mountPath resolves to workspaceDir (e.g., mountPath: "."), we can't
+		// overlay the workspace with a separate volume mount because it would shadow
+		// files already in the workspace emptyDir (e.g., task.md from context-init).
+		// Instead, git-init copies the cloned content into the workspace emptyDir.
+		isWorkspaceRoot := filepath.Clean(gm.mountPath) == filepath.Clean(cfg.workspaceDir)
 
-		// Add volume mount to agent container
-		// If repoPath is specified, use subPath to mount only that path
-		subPath := DefaultGitLink
-		if gm.repoPath != "" {
-			subPath = DefaultGitLink + "/" + strings.TrimPrefix(gm.repoPath, "/")
+		// Build init container for git clone
+		gitInitContainer := buildGitInitContainer(gm, volumeName, i, sysCfg)
+
+		if isWorkspaceRoot {
+			// Workspace root mode: after cloning, git-init merges repo content
+			// into the workspace emptyDir so task.md and repo files coexist.
+			gitInitContainer.Env = append(gitInitContainer.Env,
+				corev1.EnvVar{Name: "GIT_WORKSPACE_DIR", Value: cfg.workspaceDir},
+			)
+			if gm.repoPath != "" {
+				gitInitContainer.Env = append(gitInitContainer.Env,
+					corev1.EnvVar{Name: "GIT_REPO_SUBPATH", Value: gm.repoPath},
+				)
+			}
+			gitInitContainer.VolumeMounts = append(gitInitContainer.VolumeMounts,
+				corev1.VolumeMount{
+					Name:      WorkspaceVolumeName,
+					MountPath: cfg.workspaceDir,
+				},
+			)
 		}
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      volumeName,
-			MountPath: gm.mountPath,
-			SubPath:   subPath,
-		})
+
+		initContainers = append(initContainers, gitInitContainer)
+
+		if !isWorkspaceRoot {
+			// Normal case: mount git volume at the specified path in agent container.
+			// If repoPath is specified, use subPath to mount only that path.
+			subPath := DefaultGitLink
+			if gm.repoPath != "" {
+				subPath = DefaultGitLink + "/" + strings.TrimPrefix(gm.repoPath, "/")
+			}
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      volumeName,
+				MountPath: gm.mountPath,
+				SubPath:   subPath,
+			})
+		}
 	}
 
 	// If we have Git mounts, add GIT_CONFIG_GLOBAL to point to shared gitconfig


### PR DESCRIPTION
## Summary

Fixes a bug where Git contexts with `mountPath: "."` (workspace root) would shadow files written by `context-init` (e.g., `task.md`), causing tasks to fail.

## Problem

When an Agent uses `mountPath: .` for a Git context (common in the "Repo as Agent" pattern), the controller creates two overlapping volume mounts:

1. **Workspace emptyDir** at `/workspace` — contains `task.md` from context-init
2. **Git-context volume** at `/workspace/.` (subPath: repo) — contains the cloned repo

Since `/workspace/.` resolves to `/workspace/`, the git-context mount **shadows** the workspace emptyDir. The agent container cannot read `task.md`, and OpenCode fails with:

```
cat: /workspace/task.md: No such file or directory
Error: You must provide a message or a command
```

## Fix

The controller now detects when a Git context's `mountPath` resolves to `workspaceDir` and switches to a **merge strategy**:

1. `git-init` clones the repo into its own emptyDir volume (unchanged)
2. `git-init` then **copies** the repo content into the workspace emptyDir via `cp -a`
3. The git-context volume is **not mounted** at workspace root in the agent container

This allows `task.md` (from context-init) and repo content (`.git/`, `AGENTS.md`, `.opencode/skills/`) to coexist in the same workspace.

### Changes

| File | Change |
|------|--------|
| `cmd/kubeopencode/git_init.go` | Add `GIT_WORKSPACE_DIR` env var support — after cloning, copy repo content to workspace |
| `internal/controller/pod_builder.go` | Detect workspace-root mounts, pass env vars and workspace volume to git-init, skip overlapping volume mount |

## "Repo as Agent" Configuration Guide

This fix enables the **Repo as Agent** pattern where a Git repository defines the agent's identity (skills, instructions, contexts):

### Recommended Agent Configuration

```yaml
apiVersion: kubeopencode.io/v1alpha1
kind: Agent
metadata:
  name: my-agent
spec:
  workspaceDir: /workspace
  # No custom command needed - default works
  contexts:
    # Agent identity repo (with AGENTS.md, .opencode/skills/)
    # mountPath: . merges repo into workspace root for auto-discovery
    - name: agent-repo
      type: Git
      git:
        repository: https://github.com/org/agent-repo.git
        ref: main
      mountPath: .       # <-- workspace root, enables skill auto-discovery

    # Business/target repo for the agent to work on
    - name: target-repo
      type: Git
      git:
        repository: https://github.com/org/target-repo.git
        ref: main
      mountPath: target  # <-- subdirectory, normal volume mount
```

### Key Points

| Parameter | Agent Repo (identity) | Business Repo (target) |
|-----------|----------------------|----------------------|
| `mountPath` | `.` (workspace root) | Named subdirectory (e.g., `target`) |
| Purpose | AGENTS.md, .opencode/skills/ discovery | Code the agent works on |
| Volume strategy | Merge into workspace emptyDir | Normal subPath mount |

### Repo Structure (Agent Repo)

```
agent-repo/
├── AGENTS.md                          # Agent instructions (OpenCode native)
├── .opencode/skills/                  # Skills (OpenCode native)
│   ├── pr-review/SKILL.md
│   └── deploy/SKILL.md
├── .claude/                           # Claude Code compatible (optional)
│   ├── CLAUDE.md -> ../AGENTS.md      # Symlink for compatibility
│   └── skills/ -> ../.opencode/skills # Symlink for compatibility
```

## Test Plan

- [ ] Unit tests pass (`make test`)
- [ ] Lint passes (`make lint`)
- [ ] Verify task with `mountPath: .` can read `task.md` and discover skills
- [ ] Verify task with `mountPath: subdir` still works (no regression)
- [ ] Verify `repoPath` + workspace root merge works

🤖 Generated with [Claude Code](https://claude.com/claude-code)