### PR TITLE
chore: prepare v0.0.3 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -918,7 +918,7 @@ kubectl logs <pod-name> -n kubeopencode-system
 
 ## Project Status
 
-- **Version**: v0.0.2
+- **Version**: v0.0.3
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 - **Maintainer**: kubeopencode/kubeopencode team

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.2
+VERSION ?= 0.0.3
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.1.60
 IMG_REGISTRY ?= quay.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.2
+VERSION ?= 0.0.3
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.2
-appVersion: "v0.0.2"
+version: 0.0.3
+appVersion: "v0.0.3"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

- Bump VERSION to `0.0.3` in `Makefile` and `agents/Makefile`
- Update `Chart.yaml` version to `0.0.3` and appVersion to `v0.0.3`
- Update `CLAUDE.md` project status version

## Changes since v0.0.2

- **fix(controller)**: prevent Git context from shadowing workspace files when mountPath is workspace root (#73)
- **fix(agents)**: add curl retry for OpenCode binary download
- **docs**: add standardized release notes format to releasing SOP

## Test plan

- [x] `make verify` — generated code up to date
- [x] `make test` — all unit tests pass
- [x] `make integration-test` — 54/54 pass
- [x] `make lint` — 0 issues
- [x] `helm template` — image tags resolve to `v0.0.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)