### PR TITLE
chore: prepare v0.0.4 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -893,7 +893,7 @@ kubectl logs <pod-name> -n kubeopencode-system
 
 ## Project Status
 
-- **Version**: v0.0.3
+- **Version**: v0.0.4
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 - **Maintainer**: kubeopencode/kubeopencode team

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.3
+VERSION ?= 0.0.4
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.1.60
 IMG_REGISTRY ?= quay.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.3
+VERSION ?= 0.0.4
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.3
-appVersion: "v0.0.3"
+version: 0.0.4
+appVersion: "v0.0.4"
 keywords:
   - automation
   - ai-agent

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -28,11 +28,11 @@ import (
 )
 
 var (
-	k8sClient  client.Client
-	clientset  *kubernetes.Clientset
-	ctx        context.Context
-	cancel     context.CancelFunc
-	scheme     *runtime.Scheme
+	k8sClient client.Client
+	clientset *kubernetes.Clientset
+	ctx       context.Context
+	cancel    context.CancelFunc
+	scheme    *runtime.Scheme
 	testNS    string
 	echoImage string
 )

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -1553,4 +1553,3 @@ func (r *TaskReconciler) recordTaskDuration(task *kubeopenv1alpha1.Task) {
 	}
 	TaskDurationSeconds.WithLabelValues(task.Namespace, agentName).Observe(duration)
 }
-

--- a/internal/server/handlers/agent_handler.go
+++ b/internal/server/handlers/agent_handler.go
@@ -184,17 +184,17 @@ func agentToResponse(agent *kubeopenv1alpha1.Agent) types.AgentResponse {
 	}
 
 	resp := types.AgentResponse{
-		Name:              agent.Name,
-		Namespace:         agent.Namespace,
-		Profile:           agent.Spec.Profile,
-		ExecutorImage:     agent.Spec.ExecutorImage,
-		AgentImage:        agent.Spec.AgentImage,
-		WorkspaceDir:      agent.Spec.WorkspaceDir,
-		ContextsCount:     len(agent.Spec.Contexts),
-		CredentialsCount:  len(agent.Spec.Credentials),
-		CreatedAt:         agent.CreationTimestamp.Time,
-		Labels:            agent.Labels,
-		Mode:              mode,
+		Name:             agent.Name,
+		Namespace:        agent.Namespace,
+		Profile:          agent.Spec.Profile,
+		ExecutorImage:    agent.Spec.ExecutorImage,
+		AgentImage:       agent.Spec.AgentImage,
+		WorkspaceDir:     agent.Spec.WorkspaceDir,
+		ContextsCount:    len(agent.Spec.Contexts),
+		CredentialsCount: len(agent.Spec.Credentials),
+		CreatedAt:        agent.CreationTimestamp.Time,
+		Labels:           agent.Labels,
+		Mode:             mode,
 	}
 
 	if agent.Spec.MaxConcurrentTasks != nil {


### PR DESCRIPTION
## Summary

- Update VERSION to 0.0.4 in Makefile and agents/Makefile
- Update Chart.yaml version to 0.0.4 and appVersion to v0.0.4
- Update CLAUDE.md project status version
- Fix gofmt formatting issues from previous PR

## Test plan

- [x] `make verify` — generated code is up to date
- [x] `make test` — unit tests pass
- [x] `make integration-test` — 50/50 integration tests pass
- [x] `make lint` — 0 issues
- [x] `go run -ldflags "-X main.Version=0.0.4" ./cmd/kubeopencode version` — outputs `kubeopencode version 0.0.4`
- [x] `helm template kubeopencode charts/kubeopencode | grep 'image:'` — shows `v0.0.4` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)