### PR TITLE
chore: prepare v0.0.5 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -894,7 +894,7 @@ kubectl logs <pod-name> -n kubeopencode-system
 
 ## Project Status
 
-- **Version**: v0.0.4
+- **Version**: v0.0.5
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 - **Maintainer**: kubeopencode/kubeopencode team

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.4
+VERSION ?= 0.0.5
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.1.60
 IMG_REGISTRY ?= quay.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.4
+VERSION ?= 0.0.5
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.4
-appVersion: "v0.0.4"
+version: 0.0.5
+appVersion: "v0.0.5"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

- Update VERSION to `0.0.5` in `Makefile` and `agents/Makefile`
- Update `Chart.yaml` version to `0.0.5` and appVersion to `v0.0.5`
- Update `CLAUDE.md` project status version

## Verification

- [x] `make verify` — generated code up to date
- [x] `make test` — unit tests pass
- [x] `go run ... version` — outputs `kubeopencode version 0.0.5`
- [x] `helm template` — renders `quay.io/kubeopencode/kubeopencode:v0.0.5`

## Changes since v0.0.4

- feat(ui): redesign layout with sidebar navigation (#84)
- refactor(controller): extract common server labels (#82)
- chore(agents): bump opencode version to 1.2.27 (#83)
- fix(rbac): add tasks/finalizers permission to controller ClusterRole (#81)
- chore(deps): Bump dorny/paths-filter from 3 to 4 (#80)
- chore(deps): Bump undici from 7.21.0 to 7.24.1 in /ui (#79)
- docs: add Upgrade SOP and CRD change reminder to Release SOP
- chore: add node_modules/ to gitignore globally

🤖 Generated with [Claude Code](https://claude.com/claude-code)