### PR TITLE
feat(git): add optional recurseSubmodules support for Git context

### DIFF
--- a/api/v1alpha1/context_types.go
+++ b/api/v1alpha1/context_types.go
@@ -78,6 +78,12 @@ type GitContext struct {
 	// +kubebuilder:default=1
 	Depth *int `json:"depth,omitempty"`
 
+	// RecurseSubmodules enables recursive cloning of Git submodules.
+	// If true, submodules are initialized and cloned along with the repository.
+	// Defaults to false (submodules are not cloned).
+	// +optional
+	RecurseSubmodules bool `json:"recurseSubmodules,omitempty"`
+
 	// SecretRef references a Secret containing Git credentials.
 	// The Secret should contain one of:
 	//   - "username" + "password": For HTTPS token-based auth (password can be a PAT)

--- a/charts/kubeopencode/crds/kubeopencode.io_agents.yaml
+++ b/charts/kubeopencode/crds/kubeopencode.io_agents.yaml
@@ -184,6 +184,12 @@ spec:
 
                             Example: ".claude/", "docs/guide.md"
                           type: string
+                        recurseSubmodules:
+                          description: |-
+                            RecurseSubmodules enables recursive cloning of Git submodules.
+                            If true, submodules are initialized and cloned along with the repository.
+                            Defaults to false (submodules are not cloned).
+                          type: boolean
                         ref:
                           default: HEAD
                           description: |-

--- a/charts/kubeopencode/crds/kubeopencode.io_tasks.yaml
+++ b/charts/kubeopencode/crds/kubeopencode.io_tasks.yaml
@@ -142,6 +142,12 @@ spec:
 
                             Example: ".claude/", "docs/guide.md"
                           type: string
+                        recurseSubmodules:
+                          description: |-
+                            RecurseSubmodules enables recursive cloning of Git submodules.
+                            If true, submodules are initialized and cloned along with the repository.
+                            Defaults to false (submodules are not cloned).
+                          type: boolean
                         ref:
                           default: HEAD
                           description: |-

--- a/cmd/kubeopencode/git_init.go
+++ b/cmd/kubeopencode/git_init.go
@@ -24,8 +24,9 @@ const (
 	envPassword        = "GIT_PASSWORD"
 	envSSHKey          = "GIT_SSH_KEY"
 	envSSHHostKeys     = "GIT_SSH_KNOWN_HOSTS"
-	envGitWorkspaceDir = "GIT_WORKSPACE_DIR"
-	envGitRepoSubpath  = "GIT_REPO_SUBPATH"
+	envGitWorkspaceDir       = "GIT_WORKSPACE_DIR"
+	envGitRepoSubpath        = "GIT_REPO_SUBPATH"
+	envGitRecurseSubmodules  = "GIT_RECURSE_SUBMODULES"
 )
 
 // Default values for git-init
@@ -59,8 +60,9 @@ Environment variables:
   GIT_LINK            Subdirectory name, default: repo
   GIT_USERNAME        HTTPS username
   GIT_PASSWORD        HTTPS password/token
-  GIT_SSH_KEY         SSH private key (content or file path)
-  GIT_SSH_KNOWN_HOSTS Known hosts content for SSH verification`,
+  GIT_SSH_KEY             SSH private key (content or file path)
+  GIT_SSH_KNOWN_HOSTS     Known hosts content for SSH verification
+  GIT_RECURSE_SUBMODULES  If "true", recursively clone submodules`,
 	RunE: runGitInit,
 }
 
@@ -104,8 +106,16 @@ func runGitInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create root directory: %w", err)
 	}
 
+	// Check if submodule cloning is enabled
+	recurseSubmodules := os.Getenv(envGitRecurseSubmodules) == "true"
+
 	// Build git clone command
 	cloneArgs := []string{"clone", "--depth", strconv.Itoa(depth), "--single-branch"}
+
+	if recurseSubmodules {
+		cloneArgs = append(cloneArgs, "--recurse-submodules")
+		fmt.Println("  Submodules: recursive")
+	}
 
 	// Add branch flag if not HEAD
 	if ref != "HEAD" {

--- a/deploy/crds/kubeopencode.io_agents.yaml
+++ b/deploy/crds/kubeopencode.io_agents.yaml
@@ -184,6 +184,12 @@ spec:
 
                             Example: ".claude/", "docs/guide.md"
                           type: string
+                        recurseSubmodules:
+                          description: |-
+                            RecurseSubmodules enables recursive cloning of Git submodules.
+                            If true, submodules are initialized and cloned along with the repository.
+                            Defaults to false (submodules are not cloned).
+                          type: boolean
                         ref:
                           default: HEAD
                           description: |-

--- a/deploy/crds/kubeopencode.io_tasks.yaml
+++ b/deploy/crds/kubeopencode.io_tasks.yaml
@@ -142,6 +142,12 @@ spec:
 
                             Example: ".claude/", "docs/guide.md"
                           type: string
+                        recurseSubmodules:
+                          description: |-
+                            RecurseSubmodules enables recursive cloning of Git submodules.
+                            If true, submodules are initialized and cloned along with the repository.
+                            Defaults to false (submodules are not cloned).
+                          type: boolean
                         ref:
                           default: HEAD
                           description: |-

--- a/internal/controller/pod_builder.go
+++ b/internal/controller/pod_builder.go
@@ -77,13 +77,14 @@ type dirMount struct {
 
 // gitMount represents a Git repository to be cloned and mounted
 type gitMount struct {
-	contextName string // Context name (for volume naming)
-	repository  string // Git repository URL
-	ref         string // Git reference (branch, tag, or commit SHA)
-	repoPath    string // Path within the repository to mount
-	mountPath   string // Where to mount in the container
-	depth       int    // Clone depth (1 = shallow, 0 = full)
-	secretName  string // Optional secret name for authentication
+	contextName       string // Context name (for volume naming)
+	repository        string // Git repository URL
+	ref               string // Git reference (branch, tag, or commit SHA)
+	repoPath          string // Path within the repository to mount
+	mountPath         string // Where to mount in the container
+	depth             int    // Clone depth (1 = shallow, 0 = full)
+	secretName        string // Optional secret name for authentication
+	recurseSubmodules bool   // Whether to recursively clone submodules
 }
 
 // resolvedContext holds a resolved context with its content and metadata
@@ -269,6 +270,12 @@ func buildGitInitContainer(gm gitMount, volumeName string, index int, sysCfg sys
 		{Name: "GIT_DEPTH", Value: strconv.Itoa(depth)},
 		{Name: "GIT_ROOT", Value: DefaultGitRoot},
 		{Name: "GIT_LINK", Value: DefaultGitLink},
+	}
+
+	if gm.recurseSubmodules {
+		envVars = append(envVars, corev1.EnvVar{
+			Name: "GIT_RECURSE_SUBMODULES", Value: "true",
+		})
 	}
 
 	volumeMounts := []corev1.VolumeMount{

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -870,13 +870,14 @@ func (r *TaskReconciler) resolveContextContent(ctx context.Context, namespace, n
 		}
 
 		return "", nil, &gitMount{
-			contextName: name,
-			repository:  git.Repository,
-			ref:         ref,
-			repoPath:    git.Path,
-			mountPath:   resolvedMountPath,
-			depth:       depth,
-			secretName:  secretName,
+			contextName:       name,
+			repository:        git.Repository,
+			ref:               ref,
+			repoPath:          git.Path,
+			mountPath:         resolvedMountPath,
+			depth:             depth,
+			secretName:        secretName,
+			recurseSubmodules: git.RecurseSubmodules,
 		}, nil
 
 	case kubeopenv1alpha1.ContextTypeRuntime:


### PR DESCRIPTION
## Summary

- Add `recurseSubmodules` field to `GitContext` API for optional recursive cloning of Git submodules
- Default is `false`, preserving existing behavior (no submodule cloning)
- When enabled, `git-init` passes `--recurse-submodules` to the clone command

## Changes

| File | Change |
|------|--------|
| `api/v1alpha1/context_types.go` | Add `RecurseSubmodules bool` field to `GitContext` |
| `internal/controller/pod_builder.go` | Add field to `gitMount` struct, pass `GIT_RECURSE_SUBMODULES` env var |
| `internal/controller/task_controller.go` | Wire `RecurseSubmodules` from API to `gitMount` |
| `cmd/kubeopencode/git_init.go` | Handle env var, append `--recurse-submodules` to clone args |
| CRD YAMLs | Auto-generated via `make update` |

## Usage

```yaml
contexts:
  - name: my-repo
    type: Git
    git:
      repository: https://github.com/org/repo-with-submodules.git
      ref: main
      recurseSubmodules: true
    mountPath: source-code
```

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] `make verify` passes (generated code up to date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)