### PR TITLE
chore: prepare v0.0.8 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -894,7 +894,7 @@ kubectl logs <pod-name> -n kubeopencode-system
 
 ## Project Status
 
-- **Version**: v0.0.7
+- **Version**: v0.0.8
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 - **Maintainer**: kubeopencode/kubeopencode team

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.7
+VERSION ?= 0.0.8
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.1.60
 IMG_REGISTRY ?= quay.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.7
+VERSION ?= 0.0.8
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.7
-appVersion: "v0.0.7"
+version: 0.0.8
+appVersion: "v0.0.8"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

Version bump for v0.0.8 release.

- Update `VERSION` to `0.0.8` in `Makefile` and `agents/Makefile`
- Update `Chart.yaml` version to `0.0.8` and appVersion to `v0.0.8`
- Update `CLAUDE.md` project status version

## What's in v0.0.8

- **fix(controller)**: Inject SSH credentials (`GIT_SSH_KEY`, `GIT_SSH_KNOWN_HOSTS`) into git-init containers (#93)
- **docs**: Git authentication guide for private repositories (GitHub, GitLab, Bitbucket, Azure DevOps)

## Test plan

- [x] `make verify` passes
- [x] `make test` passes
- [x] `make lint` passes
- [x] `helm template` renders correct image tag `v0.0.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)