### PR TITLE
chore: prepare v0.0.9 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -894,7 +894,7 @@ kubectl logs <pod-name> -n kubeopencode-system
 
 ## Project Status
 
-- **Version**: v0.0.8
+- **Version**: v0.0.9
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 - **Maintainer**: kubeopencode/kubeopencode team

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.8
+VERSION ?= 0.0.9
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.1.60
 IMG_REGISTRY ?= quay.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.8
+VERSION ?= 0.0.9
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.8
-appVersion: "v0.0.8"
+version: 0.0.9
+appVersion: "v0.0.9"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

Prepare v0.0.9 release with version bumps.

- Update VERSION to 0.0.9 in Makefile and agents/Makefile
- Update Chart.yaml version to 0.0.9 and appVersion to v0.0.9
- Update CLAUDE.md project status version

## What's in v0.0.9

This release includes all changes from PR #96:

- HITL infrastructure (SSE proxy, permission endpoints, Web UI panel)
- `koc` CLI with `agent attach` and `session watch/attach`
- Server-mode bug fixes (credentials, HOME/SHELL, Agent contexts)
- Shared context resolution (`context_processor.go`)
- OpenCode integration tests with free models
- ADR-0016 (Human-in-the-Loop design)

## Test plan

- [x] `make verify` passes
- [x] `make test` passes
- [x] `go run ./cmd/kubeopencode version` shows 0.0.9
- [x] `helm template` shows correct image tag `v0.0.9`

---
Generated with [Claude Code](https://claude.com/claude-code)