### PR TITLE
chore: prepare v0.0.10 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -894,7 +894,7 @@ kubectl logs <pod-name> -n kubeopencode-system
 
 ## Project Status
 
-- **Version**: v0.0.9
+- **Version**: v0.0.10
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 - **Maintainer**: kubeopencode/kubeopencode team

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.9
+VERSION ?= 0.0.10
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.1.60
 IMG_REGISTRY ?= quay.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.9
+VERSION ?= 0.0.10
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.9
-appVersion: "v0.0.9"
+version: 0.0.10
+appVersion: "v0.0.10"
 keywords:
   - automation
   - ai-agent

--- a/charts/kubeopencode/templates/rbac/controller-clusterrole.yaml
+++ b/charts/kubeopencode/templates/rbac/controller-clusterrole.yaml
@@ -41,11 +41,12 @@ rules:
   - get
   - update
   - patch
-# Task finalizers (required for creating Pods/ConfigMaps with blockOwnerDeletion ownerReferences)
+# Finalizers (required for creating Pods/ConfigMaps with blockOwnerDeletion ownerReferences)
 - apiGroups:
   - kubeopencode.io
   resources:
   - tasks/finalizers
+  - agents/finalizers
   verbs:
   - update
 # ConfigMaps and Secrets (full access for task context)

--- a/cmd/kubeopencode/server.go
+++ b/cmd/kubeopencode/server.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/kubeopencode/kubeopencode/internal/server"
+	"github.com/kubeopencode/kubeopencode/internal/server/handlers"
 )
 
 func init() {
@@ -65,6 +66,9 @@ func runServer(cmd *cobra.Command, args []string) error {
 	}
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	log := ctrl.Log.WithName("server")
+
+	// Pass version from ldflags to server handlers
+	handlers.Version = Version
 
 	log.Info("Starting KubeOpenCode server", "address", serverAddress)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -35,6 +35,38 @@ kubectl auth can-i create pods \
 
 If denied, check the ClusterRole and ClusterRoleBinding are properly installed.
 
+### Server-mode Agent Fails with "cannot set blockOwnerDeletion"
+
+If controller logs show:
+
+```
+configmaps "xxx-server-context" is forbidden: cannot set blockOwnerDeletion
+if an ownerReference refers to a resource you can't set finalizers on
+```
+
+This means the controller ClusterRole is missing `agents/finalizers` permission. This is required for creating ConfigMaps and Deployments with `blockOwnerDeletion` OwnerReferences pointing to Agent resources.
+
+**Fix**: Ensure the controller ClusterRole includes `agents/finalizers`:
+
+```yaml
+- apiGroups:
+  - kubeopencode.io
+  resources:
+  - tasks/finalizers
+  - agents/finalizers    # Required for Server-mode Agents
+  verbs:
+  - update
+```
+
+Or patch it directly:
+
+```bash
+kubectl patch clusterrole kubeopencode-controller --type='json' \
+  -p='[{"op": "replace", "path": "/rules/2/resources", "value": ["tasks/finalizers", "agents/finalizers"]}]'
+```
+
+> **Note**: This issue is more likely to surface on OpenShift clusters, which enforce `blockOwnerDeletion` RBAC checks more strictly than Kind or vanilla Kubernetes clusters.
+
 ### CRDs Not Found
 
 Ensure CRDs are installed:

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -106,6 +106,7 @@ This section tracks which releases include CRD changes, so operators know when m
 
 | Version | CRD Changes | Description |
 |---------|-------------|-------------|
+| v0.0.9  | No (RBAC)   | Added `agents/finalizers` permission to controller ClusterRole (required for Server-mode Agents on OpenShift); fixed UI version display |
 | v0.0.4  | Yes         | Removed `AgentReference.Namespace`, `TaskExecutionStatus.PodNamespace`, `AgentSpec.AllowedNamespaces` |
 | v0.0.3  | No          | Bug fixes only |
 | v0.0.2  | No          | Bug fixes only |

--- a/ui/src/pages/AgentDetailPage.tsx
+++ b/ui/src/pages/AgentDetailPage.tsx
@@ -164,12 +164,19 @@ function AgentDetailPage() {
                 <p className="mt-2 text-sm text-stone-500 leading-relaxed">{agent.profile}</p>
               )}
             </div>
-            <span className={`inline-flex items-center px-3 py-1 rounded-lg text-xs font-medium border ${
+            <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-medium border ${
               agent.mode === 'Server'
-                ? 'bg-violet-50 text-violet-600 border-violet-200'
+                ? agent.serverStatus?.readyReplicas
+                  ? 'bg-violet-50 text-violet-600 border-violet-200'
+                  : 'bg-amber-50 text-amber-600 border-amber-200'
                 : 'bg-stone-50 text-stone-500 border-stone-200'
             }`}>
-              {agent.mode} Mode
+              <span className={`w-1.5 h-1.5 rounded-full ${
+                agent.mode === 'Server'
+                  ? agent.serverStatus?.readyReplicas ? 'bg-emerald-500' : 'bg-amber-500 animate-pulse'
+                  : 'bg-stone-400'
+              }`} />
+              {agent.mode} Mode{agent.mode === 'Server' && !agent.serverStatus?.readyReplicas ? ' (Not Ready)' : ''}
             </span>
           </div>
         </div>
@@ -232,27 +239,39 @@ function AgentDetailPage() {
           )}
 
           {/* Server Status */}
-          {agent.serverStatus && (
+          {agent.mode === 'Server' && (
             <div>
               <h3 className="text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider mb-3">Server Status</h3>
-              <div className="grid grid-cols-2 gap-x-6 gap-y-4">
-                <div>
-                  <dt className="text-xs text-stone-400">Deployment</dt>
-                  <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serverStatus.deploymentName}</dd>
+              {agent.serverStatus ? (
+                <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+                  <div>
+                    <dt className="text-xs text-stone-400">Deployment</dt>
+                    <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serverStatus.deploymentName}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-stone-400">Service</dt>
+                    <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serverStatus.serviceName}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-stone-400">URL</dt>
+                    <dd className="mt-1 text-sm text-stone-700 font-mono break-all">{agent.serverStatus.url}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-stone-400">Ready Replicas</dt>
+                    <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serverStatus.readyReplicas}</dd>
+                  </div>
                 </div>
-                <div>
-                  <dt className="text-xs text-stone-400">Service</dt>
-                  <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serverStatus.serviceName}</dd>
+              ) : (
+                <div className="bg-amber-50 rounded-lg p-4 border border-amber-200">
+                  <div className="flex items-center gap-2">
+                    <span className="w-2 h-2 rounded-full bg-amber-500 animate-pulse" />
+                    <p className="text-sm text-amber-700 font-medium">Server not ready</p>
+                  </div>
+                  <p className="text-xs text-amber-600 mt-1">
+                    The server deployment has not been created yet or is still starting up. Check controller logs for errors.
+                  </p>
                 </div>
-                <div>
-                  <dt className="text-xs text-stone-400">URL</dt>
-                  <dd className="mt-1 text-sm text-stone-700 font-mono break-all">{agent.serverStatus.url}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-stone-400">Ready Replicas</dt>
-                  <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serverStatus.readyReplicas}</dd>
-                </div>
-              </div>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- **fix**: Add `agents/finalizers` RBAC permission to controller ClusterRole (required for Server-mode Agents on OpenShift — `blockOwnerDeletion` enforcement)
- **fix**: Pass ldflags version to UI server handler (UI was displaying "dev" instead of actual version)
- **fix**: Show Server-mode Agent not-ready state in UI (badge + status section)
- **docs**: Add troubleshooting guide for `blockOwnerDeletion` errors, update upgrade version history
- **chore**: Bump version to 0.0.10

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] `helm template` renders correct image tags (v0.0.10)
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)