### PR TITLE
chore: prepare v0.0.11 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -894,7 +894,7 @@ kubectl logs <pod-name> -n kubeopencode-system
 
 ## Project Status
 
-- **Version**: v0.0.10
+- **Version**: v0.0.11
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 - **Maintainer**: kubeopencode/kubeopencode team

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.10
+VERSION ?= 0.0.11
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.1.60
 IMG_REGISTRY ?= quay.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.10
+VERSION ?= 0.0.11
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.10
-appVersion: "v0.0.10"
+version: 0.0.11
+appVersion: "v0.0.11"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

- Bump VERSION to `0.0.11` in `Makefile` and `agents/Makefile`
- Update `Chart.yaml` version to `0.0.11` and appVersion to `v0.0.11`
- Update `CLAUDE.md` project status version

## Test plan

- [ ] `make verify` passes
- [ ] `make test` passes
- [ ] `helm template kubeopencode charts/kubeopencode | grep image:` shows `v0.0.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)