### PR TITLE
chore: prepare v0.0.12 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -894,7 +894,7 @@ kubectl logs <pod-name> -n kubeopencode-system
 
 ## Project Status
 
-- **Version**: v0.0.11
+- **Version**: v0.0.12
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 - **Maintainer**: kubeopencode/kubeopencode team

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.11
+VERSION ?= 0.0.12
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.1.60
 IMG_REGISTRY ?= quay.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.11
+VERSION ?= 0.0.12
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.11
-appVersion: "v0.0.11"
+version: 0.0.12
+appVersion: "v0.0.12"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

- Update VERSION to 0.0.12 in Makefile and agents/Makefile
- Update Chart.yaml version to 0.0.12 and appVersion to v0.0.12
- Update CLAUDE.md project status version

## Release Highlights (v0.0.12)

- **Web Terminal**: Replace OpenCode Web UI (iframe proxy) with xterm.js + Kubernetes pod exec terminal
- **Security**: RBAC enforcement via user impersonation, same-origin WebSocket check, write mutex
- **Build simplification**: Remove bun Docker stage, BUILD_OPENCODE_UI flag, OpenCode SPA embedding
- **UI**: Agent sidebar icon changed from monitor to bot