### PR TITLE
chore: release v0.0.22

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.0.21
+- **Version**: v0.0.22
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.21
+VERSION ?= 0.0.22
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.3.17
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.21
+VERSION ?= 0.0.22
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.21
-appVersion: "v0.0.21"
+version: 0.0.22
+appVersion: "v0.0.22"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

- Bump version to v0.0.22
- Update VERSION in Makefile, agents/Makefile
- Update Chart.yaml version/appVersion
- Update CLAUDE.md project status

This release follows the registry migration from quay.io to ghcr.io (merged in previous commit).

## Verification

- `make verify` ✅
- `make test` ✅
- `make lint` — 0 issues ✅
- `helm template` shows correct image tag `ghcr.io/kubeopencode/kubeopencode:v0.0.22` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)