### PR TITLE
chore: release v0.0.23

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,7 +349,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.0.22
+- **Version**: v0.0.23
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.22
+VERSION ?= 0.0.23
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.4.3
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.22
+VERSION ?= 0.0.23
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.22
-appVersion: "v0.0.22"
+version: 0.0.23
+appVersion: "v0.0.23"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

Prepare release v0.0.23.

### Version bumps
- `Makefile`: VERSION 0.0.22 → 0.0.23
- `agents/Makefile`: VERSION 0.0.22 → 0.0.23
- `charts/kubeopencode/Chart.yaml`: version 0.0.22 → 0.0.23, appVersion v0.0.22 → v0.0.23
- `CLAUDE.md`: Project status version updated

### Changes since v0.0.22
- **feat**: extraPorts for Agent/AgentTemplate (#140), lifecycle hooks + /tools PATH fix (#145)
- **fix**: VS Code terminal binary discoverability, CI fixes
- **chore**: OpenCode upgrade 1.3.17 → 1.4.3, dependency bumps (Debian, actions/checkout)
- **docs**: Docker-in-Docker guide, VS Code in browser guide, ADR 0032

> **Note**: This release includes CRD changes (extraPorts, lifecycle hooks). Users upgrading via Helm must manually update CRDs.