### PR TITLE
feat(ui): improve usability with batch ops, YAML editing, and shared components

### DIFF
--- a/charts/kubeopencode/templates/rbac/web-user-clusterrole.yaml
+++ b/charts/kubeopencode/templates/rbac/web-user-clusterrole.yaml
@@ -41,10 +41,14 @@ rules:
 - apiGroups: ["kubeopencode.io"]
   resources: ["agents"]
   verbs: ["create", "update", "patch", "delete"]
-# Delete agent templates
+# Manage agent templates (create, update YAML, delete)
 - apiGroups: ["kubeopencode.io"]
   resources: ["agenttemplates"]
-  verbs: ["delete"]
+  verbs: ["create", "update", "delete"]
+# View and update cluster config
+- apiGroups: ["kubeopencode.io"]
+  resources: ["kubeopencodeconfigs"]
+  verbs: ["get", "list", "watch", "update"]
 # View pod status (required by task detail page)
 - apiGroups: [""]
   resources: ["pods"]

--- a/charts/kubeopencode/templates/server/clusterrole.yaml
+++ b/charts/kubeopencode/templates/server/clusterrole.yaml
@@ -22,10 +22,14 @@ rules:
 - apiGroups: ["kubeopencode.io"]
   resources: ["agents"]
   verbs: ["create", "update", "patch", "delete"]
-# Write access to AgentTemplates (update, delete via UI)
+# Write access to AgentTemplates (create, update, delete via UI)
 - apiGroups: ["kubeopencode.io"]
   resources: ["agenttemplates"]
-  verbs: ["update", "delete"]
+  verbs: ["create", "update", "delete"]
+# Write access to KubeOpenCodeConfig (update via UI YAML editor)
+- apiGroups: ["kubeopencode.io"]
+  resources: ["kubeopencodeconfigs"]
+  verbs: ["update"]
 # Read access to Pods (for status and log streaming)
 - apiGroups: [""]
   resources: ["pods"]

--- a/internal/server/handlers/agenttemplate_handler.go
+++ b/internal/server/handlers/agenttemplate_handler.go
@@ -4,6 +4,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"sort"
@@ -192,6 +193,43 @@ func (h *AgentTemplateHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeResourceOutput(w, r, http.StatusOK, &tmpl, resp)
+}
+
+// Create creates a new agent template
+func (h *AgentTemplateHandler) Create(w http.ResponseWriter, r *http.Request) {
+	namespace := chi.URLParam(r, "namespace")
+	ctx := r.Context()
+	k8sClient := h.getClient(ctx)
+
+	var req types.CreateAgentTemplateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body", err.Error())
+		return
+	}
+
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "Name is required", "")
+		return
+	}
+
+	tmpl := &kubeopenv1alpha1.AgentTemplate{}
+	tmpl.Name = req.Name
+	tmpl.Namespace = namespace
+	tmpl.Spec.WorkspaceDir = req.WorkspaceDir
+	tmpl.Spec.ServiceAccountName = req.ServiceAccountName
+	tmpl.Spec.AgentImage = req.AgentImage
+	tmpl.Spec.ExecutorImage = req.ExecutorImage
+
+	if err := k8sClient.Create(ctx, tmpl); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			writeError(w, http.StatusConflict, "AgentTemplate already exists", err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "Failed to create agent template", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, templateToResponse(tmpl))
 }
 
 // Delete deletes an agent template

--- a/internal/server/handlers/config_handler.go
+++ b/internal/server/handlers/config_handler.go
@@ -4,9 +4,12 @@ package handlers
 
 import (
 	"context"
+	"io"
 	"net/http"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
 	"github.com/kubeopencode/kubeopencode/internal/server/types"
@@ -39,6 +42,44 @@ func (h *ConfigHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	resp := configToResponse(&config)
 	writeResourceOutput(w, r, http.StatusOK, &config, resp)
+}
+
+// Update replaces the KubeOpenCodeConfig spec from a YAML body.
+func (h *ConfigHandler) Update(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	k8sClient := h.getClient(ctx)
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MiB limit
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Failed to read request body", err.Error())
+		return
+	}
+
+	var submitted kubeopenv1alpha1.KubeOpenCodeConfig
+	if err := yaml.Unmarshal(body, &submitted); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid YAML", err.Error())
+		return
+	}
+
+	var existing kubeopenv1alpha1.KubeOpenCodeConfig
+	if err := k8sClient.Get(ctx, client.ObjectKey{Name: "cluster"}, &existing); err != nil {
+		if apierrors.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, "Config not found", "Create a KubeOpenCodeConfig named 'cluster' first")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "Failed to get config", err.Error())
+		return
+	}
+
+	existing.Spec = submitted.Spec
+	if err := k8sClient.Update(ctx, &existing); err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to update config", err.Error())
+		return
+	}
+
+	resp := configToResponse(&existing)
+	writeResourceOutput(w, r, http.StatusOK, &existing, resp)
 }
 
 func configToResponse(config *kubeopenv1alpha1.KubeOpenCodeConfig) *types.ConfigResponse {

--- a/internal/server/handlers/crontask_handler.go
+++ b/internal/server/handlers/crontask_handler.go
@@ -5,13 +5,16 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/robfig/cron/v3"
 
 	"github.com/go-chi/chi/v5"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
 	"github.com/kubeopencode/kubeopencode/internal/server/types"
@@ -220,7 +223,8 @@ func (h *CronTaskHandler) Create(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, cronTaskToResponse(cronTask))
 }
 
-// Update updates an existing CronTask
+// Update updates an existing CronTask.
+// Accepts either JSON (UpdateCronTaskRequest) or YAML (full CronTask spec replacement).
 func (h *CronTaskHandler) Update(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	name := chi.URLParam(r, "name")
@@ -232,6 +236,33 @@ func (h *CronTaskHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	contentType := r.Header.Get("Content-Type")
+	if strings.Contains(contentType, "yaml") {
+		// YAML mode: full spec replacement (like Agent and AgentTemplate Update)
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MiB limit
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "Failed to read request body", err.Error())
+			return
+		}
+
+		var submitted kubeopenv1alpha1.CronTask
+		if err := yaml.Unmarshal(body, &submitted); err != nil {
+			writeError(w, http.StatusBadRequest, "Invalid YAML", err.Error())
+			return
+		}
+
+		existing.Spec = submitted.Spec
+		if err := k8sClient.Update(r.Context(), &existing); err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to update CronTask", err.Error())
+			return
+		}
+
+		writeResourceOutput(w, r, http.StatusOK, &existing, cronTaskToResponse(&existing))
+		return
+	}
+
+	// JSON mode: partial update
 	var req types.UpdateCronTaskRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "Invalid request body", err.Error())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -207,6 +207,7 @@ func (s *Server) setupRoutes() *chi.Mux {
 		r.Get("/agenttemplates", agentTemplateHandler.ListAll)
 		r.Route("/namespaces/{namespace}/agenttemplates", func(r chi.Router) {
 			r.Get("/", agentTemplateHandler.List)
+			r.Post("/", agentTemplateHandler.Create)
 			r.Get("/{name}", agentTemplateHandler.Get)
 			r.Put("/{name}", agentTemplateHandler.Update)
 			r.Delete("/{name}", agentTemplateHandler.Delete)
@@ -215,6 +216,7 @@ func (s *Server) setupRoutes() *chi.Mux {
 		// Config endpoint (cluster-scoped singleton)
 		configHandler := handlers.NewConfigHandler(s.k8sClient)
 		r.Get("/config", configHandler.Get)
+		r.Put("/config", configHandler.Update)
 
 		// Agent endpoints
 		r.Get("/agents", agentHandler.ListAll)

--- a/internal/server/types/types.go
+++ b/internal/server/types/types.go
@@ -344,6 +344,15 @@ type CronTaskListResponse struct {
 	Pagination *Pagination        `json:"pagination,omitempty"`
 }
 
+// CreateAgentTemplateRequest represents a request to create an agent template
+type CreateAgentTemplateRequest struct {
+	Name               string `json:"name"`
+	WorkspaceDir       string `json:"workspaceDir,omitempty"`
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+	AgentImage         string `json:"agentImage,omitempty"`
+	ExecutorImage      string `json:"executorImage,omitempty"`
+}
+
 // ErrorResponse represents an error response
 type ErrorResponse struct {
 	Error   string `json:"error"`

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,10 +10,12 @@ import AgentDetailPage from './pages/AgentDetailPage';
 import AgentCreatePage from './pages/AgentCreatePage';
 import AgentTemplatesPage from './pages/AgentTemplatesPage';
 import AgentTemplateDetailPage from './pages/AgentTemplateDetailPage';
+import AgentTemplateCreatePage from './pages/AgentTemplateCreatePage';
 import CronTasksPage from './pages/CronTasksPage';
 import CronTaskCreatePage from './pages/CronTaskCreatePage';
 import CronTaskDetailPage from './pages/CronTaskDetailPage';
 import ConfigPage from './pages/ConfigPage';
+import NotFoundPage from './pages/NotFoundPage';
 
 function App() {
   return (
@@ -32,8 +34,10 @@ function App() {
           <Route path="agents/create" element={<AgentCreatePage />} />
           <Route path="agents/:namespace/:name" element={<AgentDetailPage />} />
           <Route path="templates" element={<AgentTemplatesPage />} />
+          <Route path="templates/create" element={<AgentTemplateCreatePage />} />
           <Route path="templates/:namespace/:name" element={<AgentTemplateDetailPage />} />
           <Route path="config" element={<ConfigPage />} />
+          <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Routes>
       </NamespaceProvider>

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -71,6 +71,14 @@ export interface CreatePersistenceConfig {
   workspace?: CreateVolumePersistence;
 }
 
+export interface CreateAgentTemplateRequest {
+  name: string;
+  workspaceDir?: string;
+  serviceAccountName?: string;
+  agentImage?: string;
+  executorImage?: string;
+}
+
 export interface CreateAgentRequest {
   name: string;
   profile?: string;
@@ -461,6 +469,12 @@ export const api = {
   getAgentTemplate: (namespace: string, name: string) =>
     request<AgentTemplate>(`/namespaces/${namespace}/agenttemplates/${name}`),
 
+  createAgentTemplate: (namespace: string, data: CreateAgentTemplateRequest) =>
+    request<AgentTemplate>(`/namespaces/${namespace}/agenttemplates`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+
   deleteAgentTemplate: (namespace: string, name: string) =>
     request<void>(`/namespaces/${namespace}/agenttemplates/${name}`, { method: 'DELETE' }),
 
@@ -556,6 +570,30 @@ export const api = {
     const response = await fetch(`${API_BASE}/config?output=yaml`);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     return response.text();
+  },
+
+  updateConfigYaml: async (yaml: string): Promise<void> => {
+    const response = await fetch(`${API_BASE}/config`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/x-yaml' },
+      body: yaml,
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+      throw new Error(error.message || error.error || `HTTP ${response.status}`);
+    }
+  },
+
+  updateCronTaskYaml: async (namespace: string, name: string, yaml: string): Promise<void> => {
+    const response = await fetch(`${API_BASE}/namespaces/${namespace}/crontasks/${name}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/x-yaml' },
+      body: yaml,
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+      throw new Error(error.message || error.error || `HTTP ${response.status}`);
+    }
   },
 
 };

--- a/ui/src/components/AgentStatusBadge.tsx
+++ b/ui/src/components/AgentStatusBadge.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+interface AgentStatusBadgeProps {
+  suspended?: boolean;
+  ready?: boolean;
+}
+
+/**
+ * AgentStatusBadge renders the Live / Starting / Suspended status indicator
+ * for an Agent's server status. Replaces duplicated inline rendering across
+ * DashboardPage, AgentsPage, AgentDetailPage, and AgentTemplateDetailPage.
+ */
+function AgentStatusBadge({ suspended, ready }: AgentStatusBadgeProps) {
+  if (suspended) {
+    return (
+      <span className="inline-flex items-center text-[11px] font-medium text-amber-600">
+        <span className="mr-1.5 inline-flex rounded-full h-1.5 w-1.5 bg-amber-400" />
+        Suspended
+      </span>
+    );
+  }
+
+  if (ready) {
+    return (
+      <span className="inline-flex items-center text-[11px] font-medium text-emerald-600">
+        <span className="mr-1.5 inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
+        Live
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center text-[11px] font-medium text-violet-600">
+      <span className="relative mr-1.5 flex h-1.5 w-1.5">
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 bg-violet-400" />
+        <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-violet-400" />
+      </span>
+      Starting
+    </span>
+  );
+}
+
+export default AgentStatusBadge;

--- a/ui/src/components/Breadcrumbs.tsx
+++ b/ui/src/components/Breadcrumbs.tsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom';
 export interface BreadcrumbItem {
   label: string;
   to?: string;
+  /** If true, render as a namespace badge (monospace, muted style) */
+  isNamespace?: boolean;
 }
 
 interface BreadcrumbsProps {
@@ -29,6 +31,10 @@ function Breadcrumbs({ items }: BreadcrumbsProps) {
               <Link to={item.to} className="text-stone-400 hover:text-stone-600 transition-colors">
                 {item.label}
               </Link>
+            ) : item.isNamespace ? (
+              <span className="text-stone-400 font-mono text-xs bg-stone-100 px-1.5 py-0.5 rounded">
+                {item.label}
+              </span>
             ) : (
               <span className="text-stone-700 font-medium">{item.label}</span>
             )}

--- a/ui/src/components/CopyButton.tsx
+++ b/ui/src/components/CopyButton.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+
+interface CopyButtonProps {
+  text: string;
+  label?: string;
+  className?: string;
+}
+
+/**
+ * CopyButton copies text to the clipboard with visual feedback.
+ * Shows a checkmark icon for 2 seconds after copying.
+ */
+function CopyButton({ text, label, className }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={className || 'shrink-0 p-1.5 rounded-md text-stone-400 hover:text-stone-600 hover:bg-stone-200 transition-colors'}
+      title={label || 'Copy to clipboard'}
+    >
+      {copied ? (
+        <svg className="w-4 h-4 text-emerald-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M20 6L9 17l-5-5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      ) : (
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+export default CopyButton;

--- a/ui/src/components/SortableHeader.tsx
+++ b/ui/src/components/SortableHeader.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface SortableHeaderProps {
+  label: string;
+  active: boolean;
+  order: 'asc' | 'desc';
+  onToggle: () => void;
+  className?: string;
+}
+
+/**
+ * SortableHeader renders a clickable table column header with sort direction indicator.
+ */
+function SortableHeader({ label, active, order, onToggle, className }: SortableHeaderProps) {
+  return (
+    <th
+      className={`px-5 py-3 text-left text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider cursor-pointer select-none hover:text-stone-600 transition-colors ${className || ''}`}
+      onClick={onToggle}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        <svg className={`w-3 h-3 transition-transform ${active ? 'text-stone-600' : 'text-stone-300'} ${active && order === 'asc' ? 'rotate-180' : ''}`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+          <path d="M6 9l6 6 6-6" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </span>
+    </th>
+  );
+}
+
+export default SortableHeader;

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -113,6 +113,10 @@ export const handlers = [
   }),
 
   // === Config ===
+  http.put(`${API_BASE}/config`, () => {
+    return HttpResponse.json(mockConfig);
+  }),
+
   http.get(`${API_BASE}/config`, ({ request }) => {
     const url = new URL(request.url);
     if (url.searchParams.get('output') === 'yaml') {
@@ -429,6 +433,25 @@ export const handlers = [
     const url = new URL(request.url);
     const filtered = filterByNamespace(mockAgentTemplates, params.namespace as string);
     return HttpResponse.json(buildTemplateListResponse(filtered, url));
+  }),
+
+  http.post(`${API_BASE}/namespaces/:namespace/agenttemplates`, async ({ params, request }) => {
+    const { namespace } = params;
+    const body = await request.json() as Record<string, unknown>;
+    const newTemplate: AgentTemplate = {
+      name: (body.name as string) || `template-${Date.now()}`,
+      namespace: namespace as string,
+      workspaceDir: (body.workspaceDir as string) || '/workspace',
+      serviceAccountName: body.serviceAccountName as string,
+      agentImage: body.agentImage as string,
+      executorImage: body.executorImage as string,
+      agentCount: 0,
+      contextsCount: 0,
+      credentialsCount: 0,
+      skillsCount: 0,
+      createdAt: new Date().toISOString(),
+    };
+    return HttpResponse.json(newTemplate, { status: 201 });
   }),
 
   http.get(`${API_BASE}/namespaces/:namespace/agenttemplates/:name`, ({ params, request }) => {

--- a/ui/src/pages/AgentDetailPage.tsx
+++ b/ui/src/pages/AgentDetailPage.tsx
@@ -4,6 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 import api from '../api/client';
 import { useToast } from '../contexts/ToastContext';
 import Labels from '../components/Labels';
+import AgentStatusBadge from '../components/AgentStatusBadge';
+import CopyButton from '../components/CopyButton';
+import ConfirmDialog from '../components/ConfirmDialog';
 import Breadcrumbs from '../components/Breadcrumbs';
 import YamlViewer from '../components/YamlViewer';
 import TerminalPanel from '../components/TerminalPanel';
@@ -66,33 +69,6 @@ function SuspendResumeButton({ namespace, name, suspended, onSuccess }: { namesp
   );
 }
 
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-  const handleCopy = () => {
-    navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-  return (
-    <button
-      onClick={handleCopy}
-      className="shrink-0 p-1.5 rounded-md text-stone-400 hover:text-stone-600 hover:bg-stone-200 transition-colors"
-      title="Copy to clipboard"
-    >
-      {copied ? (
-        <svg className="w-4 h-4 text-emerald-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-          <path d="M20 6L9 17l-5-5" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      ) : (
-        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-        </svg>
-      )}
-    </button>
-  );
-}
-
 function ServerConnectCommands({ namespace, agentName }: { namespace: string; agentName: string }) {
   const kocCmd = `kubeoc agent attach ${agentName} -n ${namespace}`;
   const goInstallCmd = 'go install github.com/kubeopencode/kubeopencode/cmd/kubeoc@latest';
@@ -121,58 +97,12 @@ function ServerConnectCommands({ namespace, agentName }: { namespace: string; ag
   );
 }
 
-function DeleteAgentButton({ namespace, name }: { namespace: string; name: string }) {
-  const [confirming, setConfirming] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const navigate = useNavigate();
-  const { addToast } = useToast();
-
-  const handleDelete = async () => {
-    setLoading(true);
-    try {
-      await api.deleteAgent(namespace, name);
-      addToast(`Agent "${name}" deleted`, 'success');
-      navigate('/agents');
-    } catch (err) {
-      addToast(`Failed to delete agent: ${(err as Error).message}`, 'error');
-      setLoading(false);
-      setConfirming(false);
-    }
-  };
-
-  if (confirming) {
-    return (
-      <div className="flex items-center gap-1.5">
-        <span className="text-xs text-red-600">Delete?</span>
-        <button
-          onClick={handleDelete}
-          disabled={loading}
-          className="px-2.5 py-1 rounded-md text-xs font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 transition-colors"
-        >
-          {loading ? '...' : 'Confirm'}
-        </button>
-        <button
-          onClick={() => setConfirming(false)}
-          className="px-2.5 py-1 rounded-md text-xs font-medium text-stone-500 bg-stone-100 hover:bg-stone-200 transition-colors"
-        >
-          Cancel
-        </button>
-      </div>
-    );
-  }
-
-  return (
-    <button
-      onClick={() => setConfirming(true)}
-      className="px-3 py-1.5 rounded-lg text-xs font-medium text-red-600 bg-red-50 border border-red-200 hover:bg-red-100 transition-colors"
-    >
-      Delete
-    </button>
-  );
-}
-
 function AgentDetailPage() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
+  const navigate = useNavigate();
+  const { addToast } = useToast();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const { data: agent, isLoading, error, refetch } = useQuery({
     queryKey: ['agent', namespace, name],
@@ -217,7 +147,7 @@ function AgentDetailPage() {
     <div className="animate-fade-in">
       <Breadcrumbs items={[
         { label: 'Agents', to: '/agents' },
-        { label: namespace! },
+        { label: namespace!, isNamespace: true },
         { label: name! },
       ]} />
 
@@ -227,25 +157,10 @@ function AgentDetailPage() {
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2.5">
                 <h2 className="font-display text-xl font-bold text-stone-900">{agent.name}</h2>
-                <span className={`inline-flex items-center text-xs font-medium ${
-                  agent.serverStatus?.suspended
-                    ? 'text-amber-600'
-                    : agent.serverStatus?.ready
-                      ? 'text-emerald-600'
-                      : 'text-violet-600'
-                }`}>
-                  {agent.serverStatus?.suspended ? (
-                    <span className="mr-1.5 inline-flex rounded-full h-1.5 w-1.5 bg-amber-400" />
-                  ) : agent.serverStatus?.ready ? (
-                    <span className="mr-1.5 inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
-                  ) : (
-                    <span className="relative mr-1.5 flex h-1.5 w-1.5">
-                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 bg-violet-400" />
-                      <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-violet-400" />
-                    </span>
-                  )}
-                  {agent.serverStatus?.suspended ? 'Suspended' : agent.serverStatus?.ready ? 'Live' : 'Starting'}
-                </span>
+                <AgentStatusBadge
+                  suspended={agent.serverStatus?.suspended}
+                  ready={agent.serverStatus?.ready}
+                />
               </div>
               <p className="text-xs text-stone-400 mt-0.5 font-mono">{agent.namespace}</p>
               {agent.profile && (
@@ -270,7 +185,12 @@ function AgentDetailPage() {
                 </svg>
                 Create Task
               </Link>
-              <DeleteAgentButton namespace={agent.namespace} name={agent.name} />
+              <button
+                onClick={() => setShowDeleteDialog(true)}
+                className="px-3 py-1.5 rounded-lg text-xs font-medium text-red-600 bg-red-50 border border-red-200 hover:bg-red-100 transition-colors"
+              >
+                Delete
+              </button>
             </div>
           </div>
         </div>
@@ -399,7 +319,10 @@ function AgentDetailPage() {
                 </div>
                 <div>
                   <dt className="text-xs text-stone-400">URL</dt>
-                  <dd className="mt-1 text-sm text-stone-700 font-mono break-all">{agent.serverStatus.url}</dd>
+                  <dd className="mt-1 flex items-center gap-1.5">
+                    <span className="text-sm text-stone-700 font-mono break-all">{agent.serverStatus.url}</span>
+                    <CopyButton text={agent.serverStatus.url || ''} />
+                  </dd>
                 </div>
                 <div>
                   <dt className="text-xs text-stone-400">Status</dt>
@@ -623,6 +546,27 @@ function AgentDetailPage() {
           await api.updateAgentYaml(namespace!, name!, yaml);
           refetch();
         }}
+      />
+
+      <ConfirmDialog
+        open={showDeleteDialog}
+        title="Delete Agent"
+        message={`Are you sure you want to delete Agent "${name}"? This will remove the deployment, service, and all associated resources. This action cannot be undone.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={async () => {
+          setShowDeleteDialog(false);
+          setDeleting(true);
+          try {
+            await api.deleteAgent(namespace!, name!);
+            addToast(`Agent "${name}" deleted`, 'success');
+            navigate('/agents');
+          } catch (err) {
+            addToast(`Failed to delete agent: ${(err as Error).message}`, 'error');
+            setDeleting(false);
+          }
+        }}
+        onCancel={() => setShowDeleteDialog(false)}
       />
     </div>
   );

--- a/ui/src/pages/AgentTemplateCreatePage.tsx
+++ b/ui/src/pages/AgentTemplateCreatePage.tsx
@@ -1,0 +1,211 @@
+import React, { useState, useMemo } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import api, { CreateAgentTemplateRequest } from '../api/client';
+import { useToast } from '../contexts/ToastContext';
+import { useNamespace } from '../contexts/NamespaceContext';
+import Breadcrumbs from '../components/Breadcrumbs';
+import SearchableSelect from '../components/SearchableSelect';
+
+function AgentTemplateCreatePage() {
+  const navigate = useNavigate();
+  const { addToast } = useToast();
+  const { namespace: globalNamespace, isAllNamespaces } = useNamespace();
+
+  const [name, setName] = useState('');
+  const [selectedNamespace, setSelectedNamespace] = useState('');
+  const [workspaceDir, setWorkspaceDir] = useState('');
+  const [serviceAccountName, setServiceAccountName] = useState('');
+  const [agentImage, setAgentImage] = useState('');
+  const [executorImage, setExecutorImage] = useState('');
+
+  const { data: namespacesData } = useQuery({
+    queryKey: ['namespaces'],
+    queryFn: () => api.getNamespaces(),
+  });
+
+  const namespaces = useMemo(
+    () => namespacesData?.namespaces || [],
+    [namespacesData]
+  );
+
+  const namespace = selectedNamespace || (isAllNamespaces ? 'default' : globalNamespace);
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreateAgentTemplateRequest) => api.createAgentTemplate(namespace, data),
+    onSuccess: (tmpl) => {
+      addToast(`Template "${tmpl.name}" created successfully`, 'success');
+      navigate(`/templates/${tmpl.namespace}/${tmpl.name}`);
+    },
+    onError: (err: Error) => {
+      addToast(`Failed to create template: ${err.message}`, 'error');
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const data: CreateAgentTemplateRequest = { name };
+    if (workspaceDir) data.workspaceDir = workspaceDir;
+    if (serviceAccountName) data.serviceAccountName = serviceAccountName;
+    if (agentImage) data.agentImage = agentImage;
+    if (executorImage) data.executorImage = executorImage;
+
+    createMutation.mutate(data);
+  };
+
+  const isValid = !!name;
+
+  const labelClass = 'block text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider mb-1.5';
+  const inputClass = 'block w-full rounded-md border-stone-200 shadow-sm focus:border-primary-500 focus:ring-primary-500 text-sm text-stone-700 placeholder:text-stone-300';
+  const monoInputClass = `${inputClass} font-mono placeholder:font-body`;
+
+  return (
+    <div className="animate-fade-in">
+      <Breadcrumbs items={[
+        { label: 'Templates', to: '/templates' },
+        { label: 'Create Template' },
+      ]} />
+
+      <div className="bg-white rounded-xl border border-stone-200 overflow-hidden shadow-sm max-w-3xl">
+        <div className="px-6 py-5 border-b border-stone-100">
+          <h2 className="font-display text-xl font-bold text-stone-900">Create Agent Template</h2>
+          <p className="text-sm text-stone-400 mt-0.5">Create a reusable base configuration for Agents</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-5 space-y-6">
+          {/* Namespace */}
+          {isAllNamespaces && namespaces.length > 0 && (
+            <div>
+              <label htmlFor="namespace" className={labelClass}>Namespace</label>
+              <SearchableSelect
+                id="namespace"
+                value={selectedNamespace}
+                onChange={setSelectedNamespace}
+                options={namespaces.map((ns) => ({ value: ns, label: ns }))}
+                placeholder="Select namespace..."
+                required
+              />
+            </div>
+          )}
+
+          {/* Name */}
+          <div>
+            <label htmlFor="name" className={labelClass}>Name</label>
+            <input
+              type="text"
+              id="name"
+              value={name}
+              onChange={(e) => {
+                const sanitized = e.target.value
+                  .toLowerCase()
+                  .replace(/\s+/g, '-')
+                  .replace(/[^a-z0-9\-.]/g, '');
+                setName(sanitized);
+              }}
+              required
+              placeholder="my-template"
+              className={inputClass}
+            />
+          </div>
+
+          {/* Workspace & ServiceAccount */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="workspaceDir" className={labelClass}>
+                Workspace Directory
+                <span className="normal-case tracking-normal text-stone-300"> (optional)</span>
+              </label>
+              <input
+                type="text"
+                id="workspaceDir"
+                value={workspaceDir}
+                onChange={(e) => setWorkspaceDir(e.target.value)}
+                placeholder="/workspace"
+                className={monoInputClass}
+              />
+            </div>
+            <div>
+              <label htmlFor="serviceAccountName" className={labelClass}>
+                Service Account
+                <span className="normal-case tracking-normal text-stone-300"> (optional)</span>
+              </label>
+              <input
+                type="text"
+                id="serviceAccountName"
+                value={serviceAccountName}
+                onChange={(e) => setServiceAccountName(e.target.value)}
+                placeholder="default"
+                className={monoInputClass}
+              />
+            </div>
+          </div>
+
+          {/* Images */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="agentImage" className={labelClass}>
+                Agent Image
+                <span className="normal-case tracking-normal text-stone-300"> (init container, optional)</span>
+              </label>
+              <input
+                type="text"
+                id="agentImage"
+                value={agentImage}
+                onChange={(e) => setAgentImage(e.target.value)}
+                placeholder="ghcr.io/kubeopencode/kubeopencode-agent-opencode:latest"
+                className={monoInputClass}
+              />
+            </div>
+            <div>
+              <label htmlFor="executorImage" className={labelClass}>
+                Executor Image
+                <span className="normal-case tracking-normal text-stone-300"> (worker container, optional)</span>
+              </label>
+              <input
+                type="text"
+                id="executorImage"
+                value={executorImage}
+                onChange={(e) => setExecutorImage(e.target.value)}
+                placeholder="ghcr.io/kubeopencode/kubeopencode-agent-devbox:latest"
+                className={monoInputClass}
+              />
+            </div>
+          </div>
+
+          <p className="text-xs text-stone-400">
+            Additional configuration (contexts, credentials, skills) can be added later via YAML editing.
+          </p>
+
+          {/* Error */}
+          {createMutation.isError && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+              <p className="text-red-700 text-sm">
+                {(createMutation.error as Error).message}
+              </p>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-end space-x-3 pt-2">
+            <Link
+              to="/templates"
+              className="px-4 py-2.5 text-sm font-medium text-stone-600 bg-stone-100 rounded-lg hover:bg-stone-200 transition-colors"
+            >
+              Cancel
+            </Link>
+            <button
+              type="submit"
+              disabled={createMutation.isPending || !isValid}
+              className="px-5 py-2.5 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              {createMutation.isPending ? 'Creating...' : 'Create Template'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default AgentTemplateCreatePage;

--- a/ui/src/pages/AgentTemplateDetailPage.tsx
+++ b/ui/src/pages/AgentTemplateDetailPage.tsx
@@ -4,62 +4,17 @@ import { useQuery } from '@tanstack/react-query';
 import api from '../api/client';
 import { useToast } from '../contexts/ToastContext';
 import Labels from '../components/Labels';
+import AgentStatusBadge from '../components/AgentStatusBadge';
+import ConfirmDialog from '../components/ConfirmDialog';
 import Breadcrumbs from '../components/Breadcrumbs';
 import YamlViewer from '../components/YamlViewer';
 import { DetailSkeleton } from '../components/Skeleton';
 
-function DeleteTemplateButton({ namespace, name }: { namespace: string; name: string }) {
-  const [confirming, setConfirming] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const navigate = useNavigate();
-  const { addToast } = useToast();
-
-  const handleDelete = async () => {
-    setLoading(true);
-    try {
-      await api.deleteAgentTemplate(namespace, name);
-      addToast(`Template "${name}" deleted`, 'success');
-      navigate('/templates');
-    } catch (err) {
-      addToast(`Failed to delete template: ${(err as Error).message}`, 'error');
-      setLoading(false);
-      setConfirming(false);
-    }
-  };
-
-  if (confirming) {
-    return (
-      <div className="flex items-center gap-1.5">
-        <span className="text-xs text-red-600">Delete?</span>
-        <button
-          onClick={handleDelete}
-          disabled={loading}
-          className="px-2.5 py-1 rounded-md text-xs font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 transition-colors"
-        >
-          {loading ? '...' : 'Confirm'}
-        </button>
-        <button
-          onClick={() => setConfirming(false)}
-          className="px-2.5 py-1 rounded-md text-xs font-medium text-stone-500 bg-stone-100 hover:bg-stone-200 transition-colors"
-        >
-          Cancel
-        </button>
-      </div>
-    );
-  }
-
-  return (
-    <button
-      onClick={() => setConfirming(true)}
-      className="px-3 py-1.5 rounded-lg text-xs font-medium text-red-600 bg-red-50 border border-red-200 hover:bg-red-100 transition-colors"
-    >
-      Delete
-    </button>
-  );
-}
-
 function AgentTemplateDetailPage() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
+  const navigate = useNavigate();
+  const { addToast } = useToast();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   const { data: tmpl, isLoading, error, refetch } = useQuery({
     queryKey: ['agent-template', namespace, name],
@@ -113,7 +68,7 @@ function AgentTemplateDetailPage() {
     <div className="animate-fade-in">
       <Breadcrumbs items={[
         { label: 'Templates', to: '/templates' },
-        { label: namespace! },
+        { label: namespace!, isNamespace: true },
         { label: name! },
       ]} />
 
@@ -134,7 +89,12 @@ function AgentTemplateDetailPage() {
                 </svg>
                 Create Agent
               </Link>
-              <DeleteTemplateButton namespace={tmpl.namespace} name={tmpl.name} />
+              <button
+                onClick={() => setShowDeleteDialog(true)}
+                className="px-3 py-1.5 rounded-lg text-xs font-medium text-red-600 bg-red-50 border border-red-200 hover:bg-red-100 transition-colors"
+              >
+                Delete
+              </button>
             </div>
           </div>
         </div>
@@ -210,25 +170,10 @@ function AgentTemplateDetailPage() {
                       </div>
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0">
-                      <span className={`inline-flex items-center text-[11px] font-medium ${
-                        agent.serverStatus?.suspended
-                          ? 'text-amber-600'
-                          : agent.serverStatus?.ready
-                            ? 'text-emerald-600'
-                            : 'text-violet-600'
-                      }`}>
-                        {agent.serverStatus?.suspended ? (
-                          <span className="mr-1.5 inline-flex rounded-full h-1.5 w-1.5 bg-amber-400" />
-                        ) : agent.serverStatus?.ready ? (
-                          <span className="mr-1.5 inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
-                        ) : (
-                          <span className="relative mr-1.5 flex h-1.5 w-1.5">
-                            <span className="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 bg-violet-400" />
-                            <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-violet-400" />
-                          </span>
-                        )}
-                        {agent.serverStatus?.suspended ? 'Suspended' : agent.serverStatus?.ready ? 'Live' : 'Starting'}
-                      </span>
+                      <AgentStatusBadge
+                        suspended={agent.serverStatus?.suspended}
+                        ready={agent.serverStatus?.ready}
+                      />
                       <svg className="w-4 h-4 text-stone-300 group-hover:text-stone-500 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                         <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
                       </svg>
@@ -346,6 +291,25 @@ function AgentTemplateDetailPage() {
           await api.updateAgentTemplateYaml(namespace!, name!, yaml);
           refetch();
         }}
+      />
+
+      <ConfirmDialog
+        open={showDeleteDialog}
+        title="Delete Template"
+        message={`Are you sure you want to delete template "${name}"? This action cannot be undone.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={async () => {
+          setShowDeleteDialog(false);
+          try {
+            await api.deleteAgentTemplate(namespace!, name!);
+            addToast(`Template "${name}" deleted`, 'success');
+            navigate('/templates');
+          } catch (err) {
+            addToast(`Failed to delete template: ${(err as Error).message}`, 'error');
+          }
+        }}
+        onCancel={() => setShowDeleteDialog(false)}
       />
     </div>
   );

--- a/ui/src/pages/AgentTemplatesPage.tsx
+++ b/ui/src/pages/AgentTemplatesPage.tsx
@@ -44,6 +44,15 @@ function AgentTemplatesPage() {
             Reusable base configurations for creating Agents
           </p>
         </div>
+        <Link
+          to="/templates/create"
+          className="inline-flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors shadow-sm"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M12 5v14M5 12h14" strokeLinecap="round" />
+          </svg>
+          Create Template
+        </Link>
       </div>
 
       <div className="mb-4">

--- a/ui/src/pages/AgentsPage.tsx
+++ b/ui/src/pages/AgentsPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import api, { Agent } from '../api/client';
 import Labels from '../components/Labels';
+import AgentStatusBadge from '../components/AgentStatusBadge';
 import Skeleton from '../components/Skeleton';
 import ResourceFilter from '../components/ResourceFilter';
 import MultiSelect from '../components/MultiSelect';
@@ -197,25 +198,10 @@ function AgentsPage() {
                       </h3>
                       <p className="text-xs text-stone-400 mt-0.5 font-mono">{agent.namespace}</p>
                     </div>
-                    <span className={`inline-flex items-center text-[11px] font-medium ${
-                      agent.serverStatus?.suspended
-                        ? 'text-amber-600'
-                        : agent.serverStatus?.ready
-                          ? 'text-emerald-600'
-                          : 'text-violet-600'
-                    }`}>
-                      {agent.serverStatus?.suspended ? (
-                        <span className="mr-1.5 inline-flex rounded-full h-1.5 w-1.5 bg-amber-400" />
-                      ) : agent.serverStatus?.ready ? (
-                        <span className="mr-1.5 inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
-                      ) : (
-                        <span className="relative mr-1.5 flex h-1.5 w-1.5">
-                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 bg-violet-400" />
-                          <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-violet-400" />
-                        </span>
-                      )}
-                      {agent.serverStatus?.suspended ? 'Suspended' : agent.serverStatus?.ready ? 'Live' : 'Starting'}
-                    </span>
+                    <AgentStatusBadge
+                      suspended={agent.serverStatus?.suspended}
+                      ready={agent.serverStatus?.ready}
+                    />
                   </div>
 
                   {agent.profile && (

--- a/ui/src/pages/ConfigPage.tsx
+++ b/ui/src/pages/ConfigPage.tsx
@@ -1,12 +1,23 @@
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import api from '../api/client';
 import Labels from '../components/Labels';
 import Breadcrumbs from '../components/Breadcrumbs';
 import YamlViewer from '../components/YamlViewer';
+import CopyButton from '../components/CopyButton';
 import { DetailSkeleton } from '../components/Skeleton';
 
+const CONFIG_TEMPLATE = `apiVersion: kubeopencode.io/v1alpha1
+kind: KubeOpenCodeConfig
+metadata:
+  name: cluster
+spec:
+  cleanup:
+    ttlSecondsAfterFinished: 3600
+    maxRetainedTasks: 100`;
+
 function ConfigPage() {
+  const queryClient = useQueryClient();
   const { data: config, isLoading, error } = useQuery({
     queryKey: ['config'],
     queryFn: () => api.getConfig(),
@@ -32,16 +43,18 @@ function ConfigPage() {
               : errorMessage}
           </p>
           {isNotFound && (
-            <pre className="mt-4 text-xs text-amber-700 bg-amber-100/50 rounded-lg p-4 font-mono overflow-x-auto">
-{`apiVersion: kubeopencode.io/v1alpha1
-kind: KubeOpenCodeConfig
-metadata:
-  name: cluster
-spec:
-  cleanup:
-    ttlSecondsAfterFinished: 3600
-    maxRetainedTasks: 100`}
-            </pre>
+            <div className="mt-4">
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-xs font-medium text-amber-700">Apply this YAML to get started:</p>
+                <CopyButton text={CONFIG_TEMPLATE} label="Copy YAML template" />
+              </div>
+              <pre className="text-xs text-amber-700 bg-amber-100/50 rounded-lg p-4 font-mono overflow-x-auto">
+{CONFIG_TEMPLATE}
+              </pre>
+              <p className="mt-3 text-xs text-amber-600">
+                Run: <code className="bg-amber-100/50 px-1.5 py-0.5 rounded font-mono">kubectl apply -f config.yaml</code>
+              </p>
+            </div>
           )}
         </div>
       </div>
@@ -172,6 +185,10 @@ spec:
       <YamlViewer
         queryKey={['config-yaml']}
         fetchYaml={() => api.getConfigYaml()}
+        onSave={async (yaml) => {
+          await api.updateConfigYaml(yaml);
+          queryClient.invalidateQueries({ queryKey: ['config'] });
+        }}
       />
     </div>
   );

--- a/ui/src/pages/CronTaskDetailPage.tsx
+++ b/ui/src/pages/CronTaskDetailPage.tsx
@@ -120,7 +120,7 @@ function CronTaskDetailPage() {
     <div className="animate-fade-in">
       <Breadcrumbs items={[
         { label: 'CronTasks', to: '/crontasks' },
-        { label: namespace! },
+        { label: namespace!, isNamespace: true },
         { label: name! },
       ]} />
 
@@ -341,6 +341,10 @@ function CronTaskDetailPage() {
       <YamlViewer
         queryKey={['crontask-yaml', namespace!, name!]}
         fetchYaml={() => api.getCronTaskYaml(namespace!, name!)}
+        onSave={async (yaml) => {
+          await api.updateCronTaskYaml(namespace!, name!, yaml);
+          queryClient.invalidateQueries({ queryKey: ['crontask', namespace, name] });
+        }}
       />
 
       {/* Execution History */}

--- a/ui/src/pages/CronTasksPage.tsx
+++ b/ui/src/pages/CronTasksPage.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import api from '../api/client';
 import TimeAgo from '../components/TimeAgo';
 import ResourceFilter from '../components/ResourceFilter';
+import SortableHeader from '../components/SortableHeader';
 import { TableSkeleton } from '../components/Skeleton';
 import { useFilterState } from '../hooks/useFilterState';
 import { useNamespace } from '../contexts/NamespaceContext';
@@ -14,6 +15,7 @@ function CronTasksPage() {
   const { namespace, isAllNamespaces } = useNamespace();
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [filters, setFilters] = useFilterState();
 
   useEffect(() => {
@@ -21,12 +23,12 @@ function CronTasksPage() {
   }, [namespace, filters.name, filters.labelSelector]);
 
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ['crontasks', namespace, currentPage, pageSize, filters.name, filters.labelSelector],
+    queryKey: ['crontasks', namespace, currentPage, pageSize, sortOrder, filters.name, filters.labelSelector],
     queryFn: () => {
       const params = {
         limit: pageSize,
         offset: (currentPage - 1) * pageSize,
-        sortOrder: 'desc' as const,
+        sortOrder,
         name: filters.name || undefined,
         labelSelector: filters.labelSelector || undefined,
       };
@@ -34,7 +36,7 @@ function CronTasksPage() {
         ? api.listAllCronTasks(params)
         : api.listCronTasks(namespace, params);
     },
-    refetchInterval: 5000,
+    refetchInterval: 30000,
   });
 
   return (
@@ -110,9 +112,12 @@ function CronTasksPage() {
                 <th className="px-5 py-3 text-left text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider hidden lg:table-cell">
                   Next Run
                 </th>
-                <th className="px-5 py-3 text-left text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider">
-                  Age
-                </th>
+                <SortableHeader
+                  label="Age"
+                  active={true}
+                  order={sortOrder}
+                  onToggle={() => { setSortOrder(o => o === 'desc' ? 'asc' : 'desc'); setCurrentPage(1); }}
+                />
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-stone-100">

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import api from '../api/client';
 import StatusBadge from '../components/StatusBadge';
+import AgentStatusBadge from '../components/AgentStatusBadge';
 import { DashboardSkeleton } from '../components/Skeleton';
 import TimeAgo from '../components/TimeAgo';
 import { useNamespace } from '../contexts/NamespaceContext';
@@ -15,7 +16,12 @@ function DashboardPage() {
     queryFn: () => isAllNamespaces
       ? api.listAllTasks({ limit: 10 })
       : api.listTasks(namespace, { limit: 10 }),
-    refetchInterval: 5000,
+    refetchInterval: (query) => {
+      const tasks = query.state.data?.tasks;
+      // Poll frequently while tasks are in active states, slow down otherwise
+      if (tasks?.some((t) => ['Running', 'Queued', 'Pending'].includes(t.phase))) return 5000;
+      return 30000;
+    },
   });
 
   const { data: agentsData, isLoading: agentsLoading } = useQuery({
@@ -167,25 +173,10 @@ function DashboardPage() {
                         </p>
                         <p className="text-xs text-stone-400 mt-0.5">{agent.namespace}</p>
                       </div>
-                      <span className={`inline-flex items-center text-[11px] font-medium ${
-                        agent.serverStatus?.suspended
-                          ? 'text-amber-600'
-                          : agent.serverStatus?.ready
-                            ? 'text-emerald-600'
-                            : 'text-violet-600'
-                      }`}>
-                        {agent.serverStatus?.suspended ? (
-                          <span className="mr-1.5 inline-flex rounded-full h-1.5 w-1.5 bg-amber-400" />
-                        ) : agent.serverStatus?.ready ? (
-                          <span className="mr-1.5 inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
-                        ) : (
-                          <span className="relative mr-1.5 flex h-1.5 w-1.5">
-                            <span className="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75 bg-violet-400" />
-                            <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-violet-400" />
-                          </span>
-                        )}
-                        {agent.serverStatus?.suspended ? 'Suspended' : agent.serverStatus?.ready ? 'Live' : 'Starting'}
-                      </span>
+                      <AgentStatusBadge
+                        suspended={agent.serverStatus?.suspended}
+                        ready={agent.serverStatus?.ready}
+                      />
                     </div>
                   </Link>
                 </li>

--- a/ui/src/pages/NotFoundPage.tsx
+++ b/ui/src/pages/NotFoundPage.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+function NotFoundPage() {
+  const location = useLocation();
+
+  return (
+    <div className="animate-fade-in flex items-center justify-center min-h-[60vh]">
+      <div className="text-center max-w-md">
+        <p className="text-6xl font-display font-bold text-stone-200">404</p>
+        <h1 className="mt-4 font-display text-xl font-semibold text-stone-800">Page Not Found</h1>
+        <p className="mt-2 text-sm text-stone-500">
+          The path <code className="bg-stone-100 px-2 py-0.5 rounded text-stone-600 font-mono text-xs">{location.pathname}</code> does not exist.
+        </p>
+        <Link
+          to="/"
+          className="mt-6 inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M19 12H5M12 19l-7-7 7-7" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          Back to Dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default NotFoundPage;

--- a/ui/src/pages/TaskDetailPage.tsx
+++ b/ui/src/pages/TaskDetailPage.tsx
@@ -89,7 +89,7 @@ function TaskDetailPage() {
     <div className="animate-fade-in">
       <Breadcrumbs items={[
         { label: 'Tasks', to: '/tasks' },
-        { label: namespace! },
+        { label: namespace!, isNamespace: true },
         { label: name! },
       ]} />
 

--- a/ui/src/pages/TasksPage.tsx
+++ b/ui/src/pages/TasksPage.tsx
@@ -1,15 +1,18 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import api from '../api/client';
 import StatusBadge from '../components/StatusBadge';
 import Labels from '../components/Labels';
 import TimeAgo from '../components/TimeAgo';
 import ResourceFilter from '../components/ResourceFilter';
 import MultiSelect from '../components/MultiSelect';
+import SortableHeader from '../components/SortableHeader';
+import ConfirmDialog from '../components/ConfirmDialog';
 import { TableSkeleton } from '../components/Skeleton';
 import { useFilterState } from '../hooks/useFilterState';
 import { useNamespace } from '../contexts/NamespaceContext';
+import { useToast } from '../contexts/ToastContext';
 import { LABEL_AGENT, LABEL_AGENT_TEMPLATE, LABEL_CRONTASK, appendLabelSelector } from '../utils/labels';
 
 const PAGE_SIZE_OPTIONS = [10, 20, 50];
@@ -25,16 +28,23 @@ type SourceFilter = '' | 'agent' | 'template';
 
 function TasksPage() {
   const { namespace, isAllNamespaces } = useNamespace();
+  const queryClient = useQueryClient();
+  const { addToast } = useToast();
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
   const [phaseFilter, setPhaseFilter] = useState<string[]>([]);
   const [agentFilter, setAgentFilter] = useState<string[]>([]);
   const [cronTaskFilter, setCronTaskFilter] = useState<string[]>([]);
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>('');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [filters, setFilters] = useFilterState();
+  const [selectedTasks, setSelectedTasks] = useState<Set<string>>(new Set());
+  const [batchAction, setBatchAction] = useState<'delete' | 'stop' | null>(null);
+  const [batchProcessing, setBatchProcessing] = useState(false);
 
   useEffect(() => {
     setCurrentPage(1);
+    setSelectedTasks(new Set());
   }, [namespace, phaseFilter, agentFilter, cronTaskFilter, sourceFilter, filters.name, filters.labelSelector]);
 
   // Reset filters when namespace changes
@@ -83,7 +93,7 @@ function TasksPage() {
   );
 
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ['tasks', namespace, currentPage, pageSize, phaseFilter, agentFilter, cronTaskFilter, sourceFilter, filters.name, filters.labelSelector],
+    queryKey: ['tasks', namespace, currentPage, pageSize, phaseFilter, agentFilter, cronTaskFilter, sourceFilter, sortOrder, filters.name, filters.labelSelector],
     queryFn: () => {
       let labelSelector = filters.labelSelector || '';
       if (agentFilter.length === 1) {
@@ -104,7 +114,7 @@ function TasksPage() {
       const params = {
         limit: pageSize,
         offset: (currentPage - 1) * pageSize,
-        sortOrder: 'desc' as const,
+        sortOrder,
         name: filters.name || undefined,
         labelSelector: labelSelector || undefined,
         phase: phaseFilter.length > 0 ? phaseFilter.join(',') : undefined,
@@ -113,8 +123,63 @@ function TasksPage() {
         ? api.listAllTasks(params)
         : api.listTasks(namespace, params);
     },
-    refetchInterval: 5000,
+    refetchInterval: (query) => {
+      const tasks = query.state.data?.tasks;
+      // Poll frequently while tasks are in active states, slow down otherwise
+      if (tasks?.some((t) => ['Running', 'Queued', 'Pending'].includes(t.phase))) return 5000;
+      return 30000;
+    },
   });
+
+  const currentTasks = data?.tasks || [];
+  const allSelected = currentTasks.length > 0 && currentTasks.every(t => selectedTasks.has(`${t.namespace}/${t.name}`));
+
+  const toggleTask = (ns: string, name: string) => {
+    const key = `${ns}/${name}`;
+    setSelectedTasks(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (allSelected) {
+      setSelectedTasks(new Set());
+    } else {
+      setSelectedTasks(new Set(currentTasks.map(t => `${t.namespace}/${t.name}`)));
+    }
+  };
+
+  const executeBatch = async (action: 'delete' | 'stop') => {
+    setBatchProcessing(true);
+    const items = Array.from(selectedTasks);
+    let success = 0;
+    let failed = 0;
+    for (const key of items) {
+      const [ns, ...nameParts] = key.split('/');
+      const name = nameParts.join('/');
+      try {
+        if (action === 'delete') {
+          await api.deleteTask(ns, name);
+        } else {
+          await api.stopTask(ns, name);
+        }
+        success++;
+      } catch {
+        failed++;
+      }
+    }
+    setBatchProcessing(false);
+    setSelectedTasks(new Set());
+    setBatchAction(null);
+    queryClient.invalidateQueries({ queryKey: ['tasks'] });
+    if (failed === 0) {
+      addToast(`${success} task(s) ${action === 'delete' ? 'deleted' : 'stopped'} successfully`, 'success');
+    } else {
+      addToast(`${success} succeeded, ${failed} failed`, failed > 0 ? 'error' : 'success');
+    }
+  };
 
   return (
     <div className="animate-fade-in">
@@ -198,9 +263,48 @@ function TasksPage() {
         </div>
       ) : (
         <div className="bg-white rounded-xl border border-stone-200 overflow-hidden shadow-sm">
+          {/* Batch action bar */}
+          {selectedTasks.size > 0 && (
+            <div className="bg-primary-50 border-b border-primary-200 px-5 py-2.5 flex items-center justify-between">
+              <span className="text-xs font-medium text-primary-700">
+                {selectedTasks.size} task(s) selected
+              </span>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setBatchAction('stop')}
+                  disabled={batchProcessing}
+                  className="px-3 py-1.5 text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-lg hover:bg-amber-100 transition-colors disabled:opacity-50"
+                >
+                  Stop Selected
+                </button>
+                <button
+                  onClick={() => setBatchAction('delete')}
+                  disabled={batchProcessing}
+                  className="px-3 py-1.5 text-xs font-medium text-red-600 bg-red-50 border border-red-200 rounded-lg hover:bg-red-100 transition-colors disabled:opacity-50"
+                >
+                  Delete Selected
+                </button>
+                <button
+                  onClick={() => setSelectedTasks(new Set())}
+                  className="px-3 py-1.5 text-xs font-medium text-stone-500 hover:text-stone-700 transition-colors"
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+          )}
+
           <table className="min-w-full divide-y divide-stone-100">
             <thead className="bg-stone-50/60">
               <tr>
+                <th className="px-3 py-3 w-8">
+                  <input
+                    type="checkbox"
+                    checked={allSelected}
+                    onChange={toggleAll}
+                    className="rounded border-stone-300 text-primary-600 focus:ring-primary-500"
+                  />
+                </th>
                 <th className="px-5 py-3 text-left text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider">
                   Name
                 </th>
@@ -221,15 +325,18 @@ function TasksPage() {
                 <th className="px-5 py-3 text-left text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider hidden sm:table-cell">
                   Duration
                 </th>
-                <th className="px-5 py-3 text-left text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider">
-                  Created
-                </th>
+                <SortableHeader
+                  label="Created"
+                  active={true}
+                  order={sortOrder}
+                  onToggle={() => { setSortOrder(o => o === 'desc' ? 'asc' : 'desc'); setCurrentPage(1); }}
+                />
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-stone-100">
               {data?.tasks.length === 0 ? (
                 <tr>
-                  <td colSpan={isAllNamespaces ? 7 : 6} className="px-5 py-12 text-center text-stone-400 text-sm">
+                  <td colSpan={isAllNamespaces ? 8 : 7} className="px-5 py-12 text-center text-stone-400 text-sm">
                     No tasks found.{' '}
                     {!isAllNamespaces && (
                       <Link to="/tasks/create" className="text-primary-600 hover:text-primary-700 font-medium">
@@ -240,7 +347,15 @@ function TasksPage() {
                 </tr>
               ) : (
                 data?.tasks.map((task) => (
-                  <tr key={`${task.namespace}/${task.name}`} className="hover:bg-stone-50/60 transition-colors">
+                  <tr key={`${task.namespace}/${task.name}`} className={`hover:bg-stone-50/60 transition-colors ${selectedTasks.has(`${task.namespace}/${task.name}`) ? 'bg-primary-50/40' : ''}`}>
+                    <td className="px-3 py-3.5 w-8">
+                      <input
+                        type="checkbox"
+                        checked={selectedTasks.has(`${task.namespace}/${task.name}`)}
+                        onChange={() => toggleTask(task.namespace, task.name)}
+                        className="rounded border-stone-300 text-primary-600 focus:ring-primary-500"
+                      />
+                    </td>
                     <td className="px-5 py-3.5 whitespace-nowrap">
                       <Link
                         to={`/tasks/${task.namespace}/${task.name}`}
@@ -352,6 +467,18 @@ function TasksPage() {
           )}
         </div>
       )}
+
+      <ConfirmDialog
+        open={batchAction !== null}
+        title={batchAction === 'delete' ? 'Delete Tasks' : 'Stop Tasks'}
+        message={`Are you sure you want to ${batchAction} ${selectedTasks.size} task(s)? ${batchAction === 'delete' ? 'This action cannot be undone.' : 'Running tasks will be stopped.'}`}
+        confirmLabel={batchAction === 'delete' ? 'Delete All' : 'Stop All'}
+        variant={batchAction === 'delete' ? 'danger' : 'warning'}
+        onConfirm={() => {
+          if (batchAction) executeBatch(batchAction);
+        }}
+        onCancel={() => setBatchAction(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Comprehensive UI usability improvements across the KubeOpenCode web dashboard:

- **New features**: AgentTemplate creation (full-stack), CronTask/Config YAML editing, batch task operations (select/stop/delete), sortable table columns
- **UX improvements**: 404 page, smart polling (5s active → 30s idle), namespace badges in breadcrumbs, one-click copy buttons, unified ConfirmDialog for destructive actions
- **Code quality**: Extracted `AgentStatusBadge`, `CopyButton`, `SortableHeader` shared components, eliminating ~80 lines of duplicated rendering logic
- **RBAC**: Updated server + web-user ClusterRoles for new `agenttemplates` create and `kubeopencodeconfigs` update permissions

## Changes

### Backend (Go)
- `POST /api/v1/namespaces/{ns}/agenttemplates` — new endpoint for creating templates
- `PUT /api/v1/config` — new endpoint for updating KubeOpenCodeConfig via YAML
- `PUT /api/v1/namespaces/{ns}/crontasks/{name}` — extended to accept YAML body (Content-Type detection)
- New `CreateAgentTemplateRequest` type in `internal/server/types/types.go`

### Frontend (React/TypeScript)
- **New pages**: `NotFoundPage`, `AgentTemplateCreatePage`
- **New components**: `AgentStatusBadge`, `CopyButton`, `SortableHeader`
- **Enhanced pages**: TasksPage (batch ops + sort), CronTasksPage (sort), ConfigPage (YAML edit + guidance), CronTaskDetailPage (YAML edit), AgentDetailPage (CopyButton + ConfirmDialog), AgentTemplateDetailPage (ConfirmDialog), AgentTemplatesPage (Create button)
- **Breadcrumbs**: namespace displayed as monospace badge
- **Smart polling**: dynamic refetchInterval based on active task presence

### Helm RBAC
- `server/clusterrole.yaml`: added `create` for `agenttemplates`, `update` for `kubeopencodeconfigs`
- `rbac/web-user-clusterrole.yaml`: added `create`, `update` for `agenttemplates`; added full CRUD for `kubeopencodeconfigs`

## Verification
- `make build` — pass
- `make test` — pass (all Go tests)
- `make lint` — pass (0 issues)
- `npx tsc --noEmit` — pass (0 errors)
- `npx vitest run` — pass (19 files, 194 tests)
- `helm template` — valid RBAC rendering confirmed