### PR TITLE
chore: release v0.0.24

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,7 +353,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.0.23
+- **Version**: v0.0.24
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.23
+VERSION ?= 0.0.24
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.4.3
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.23
+VERSION ?= 0.0.24
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.23
-appVersion: "v0.0.23"
+version: 0.0.24
+appVersion: "v0.0.24"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

- Update VERSION to 0.0.24 in Makefile and agents/Makefile
- Update Chart.yaml version to 0.0.24 and appVersion to v0.0.24
- Update CLAUDE.md project status version

## Changes since v0.0.23

- **feat**: Agent share link for token-based terminal sharing (#150)
- **feat(ui)**: Share link management UI + batch ops, YAML editing improvements (#148)
- **refactor**: Extract TaskLabelKey constant (#147)
- **docs**: Share link docs, ADR for externalURL

**Note**: This release includes CRD changes (new share fields in Agent types).