### PR TITLE
chore: release v0.0.25

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.0.24
+- **Version**: v0.0.25
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.24
+VERSION ?= 0.0.25
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.4.3
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.24
+VERSION ?= 0.0.25
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.24
-appVersion: "v0.0.24"
+version: 0.0.25
+appVersion: "v0.0.25"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

- Update VERSION to `0.0.25` in `Makefile` and `agents/Makefile`
- Update `Chart.yaml` version to `0.0.25` and appVersion to `v0.0.25`
- Update `AGENTS.md` project status version

## Changes since v0.0.24

- **feat**: First-class plugin support for Agents (`spec.plugins`) (#152)
- **refactor**: Change Agent config field from `*string` to `*runtime.RawExtension` (#153)
- **chore**: Replace CLAUDE.md with AGENTS.md as primary config file

## CRD Changes

This release includes CRD changes (new `plugins` field, config type change). Users upgrading must manually update CRDs before `helm upgrade`.