### PR TITLE
chore: release v0.0.26

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.0.25
+- **Version**: v0.0.26
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.25
+VERSION ?= 0.0.26
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.4.3
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.25
+VERSION ?= 0.0.26
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.25
-appVersion: "v0.0.25"
+version: 0.0.26
+appVersion: "v0.0.26"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

- Update VERSION to `0.0.26` in `Makefile` and `agents/Makefile`
- Update `Chart.yaml` version to `0.0.26` and appVersion to `v0.0.26`
- Update `AGENTS.md` project status version

## Changes since v0.0.25

- **feat**: display plugins and OpenCode config on Agent/AgentTemplate detail pages
- **refactor**: remove readOnly/view-only from share link feature (CRD change)
- **fix**: upgrade vite and follow-redirects to resolve security vulnerabilities
- **docs**: update config examples, add v0.0.25 to CRD changes version history

## CRD Changes

This release removes the `readOnly` field from `ShareConfig` in the Agent CRD. Users who had `spec.share.readOnly` set should remove it from their Agent manifests before upgrading.