### PR TITLE
test: add comprehensive test coverage across all tiers

### DIFF
--- a/internal/controller/context_processor_test.go
+++ b/internal/controller/context_processor_test.go
@@ -1,0 +1,861 @@
+// Copyright Contributors to the KubeOpenCode project
+
+//go:build !integration
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
+)
+
+// fakeReader implements contextReader for testing.
+type fakeReader struct {
+	configMaps map[types.NamespacedName]*corev1.ConfigMap
+}
+
+func (f *fakeReader) Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		return fmt.Errorf("unexpected object type: %T", obj)
+	}
+	stored, found := f.configMaps[key]
+	if !found {
+		return fmt.Errorf("configmap %s/%s not found", key.Namespace, key.Name)
+	}
+	*cm = *stored
+	return nil
+}
+
+func newFakeReader(cms ...*corev1.ConfigMap) *fakeReader {
+	r := &fakeReader{configMaps: make(map[types.NamespacedName]*corev1.ConfigMap)}
+	for _, cm := range cms {
+		r.configMaps[types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace}] = cm
+	}
+	return r
+}
+
+func TestHashConfigMapData_ContextProcessor(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     map[string]string
+		wantLen  int
+		wantSame bool // if true, compare with same data again
+	}{
+		{
+			name:    "empty data returns empty",
+			data:    nil,
+			wantLen: 0,
+		},
+		{
+			name:    "empty map returns empty",
+			data:    map[string]string{},
+			wantLen: 0,
+		},
+		{
+			name:    "single entry produces 16 char hash",
+			data:    map[string]string{"key": "value"},
+			wantLen: 16,
+		},
+		{
+			name:    "deterministic - same input same output",
+			data:    map[string]string{"a": "1", "b": "2"},
+			wantLen: 16,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hashConfigMapData(tt.data)
+			if len(got) != tt.wantLen {
+				t.Errorf("hashConfigMapData() length = %d, want %d", len(got), tt.wantLen)
+			}
+		})
+	}
+
+	// Determinism check
+	t.Run("same data produces same hash", func(t *testing.T) {
+		data := map[string]string{"a": "1", "b": "2"}
+		h1 := hashConfigMapData(data)
+		h2 := hashConfigMapData(data)
+		if h1 != h2 {
+			t.Errorf("hashes differ for same input: %s vs %s", h1, h2)
+		}
+	})
+
+	// Order independence
+	t.Run("different key order produces same hash", func(t *testing.T) {
+		data1 := map[string]string{"a": "1", "b": "2", "c": "3"}
+		data2 := map[string]string{"c": "3", "a": "1", "b": "2"}
+		h1 := hashConfigMapData(data1)
+		h2 := hashConfigMapData(data2)
+		if h1 != h2 {
+			t.Errorf("hashes differ for different key order: %s vs %s", h1, h2)
+		}
+	})
+
+	// Different data produces different hash
+	t.Run("different data produces different hash", func(t *testing.T) {
+		h1 := hashConfigMapData(map[string]string{"key": "value1"})
+		h2 := hashConfigMapData(map[string]string{"key": "value2"})
+		if h1 == h2 {
+			t.Errorf("hashes should differ for different values")
+		}
+	})
+}
+
+func TestResolveContextContentFromReader_Text(t *testing.T) {
+	reader := newFakeReader()
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		item        *kubeopenv1alpha1.ContextItem
+		wantContent string
+	}{
+		{
+			name: "text context returns content",
+			item: &kubeopenv1alpha1.ContextItem{
+				Type: kubeopenv1alpha1.ContextTypeText,
+				Text: "hello world",
+			},
+			wantContent: "hello world",
+		},
+		{
+			name: "empty text returns empty",
+			item: &kubeopenv1alpha1.ContextItem{
+				Type: kubeopenv1alpha1.ContextTypeText,
+				Text: "",
+			},
+			wantContent: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, dm, gm, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", tt.item, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if dm != nil || gm != nil {
+				t.Fatal("expected no dir/git mounts for text context")
+			}
+			if content != tt.wantContent {
+				t.Errorf("content = %q, want %q", content, tt.wantContent)
+			}
+		})
+	}
+}
+
+func TestResolveContextContentFromReader_ConfigMap(t *testing.T) {
+	reader := newFakeReader(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cm", Namespace: "default"},
+		Data:       map[string]string{"key1": "value1", "key2": "value2"},
+	})
+	ctx := context.Background()
+
+	t.Run("configMap with specific key", func(t *testing.T) {
+		key := "key1"
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeConfigMap,
+			ConfigMap: &kubeopenv1alpha1.ConfigMapContext{
+				Name: "my-cm",
+				Key:  key,
+			},
+		}
+		content, dm, gm, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dm != nil || gm != nil {
+			t.Fatal("expected no dir/git mounts")
+		}
+		if content != "value1" {
+			t.Errorf("content = %q, want %q", content, "value1")
+		}
+	})
+
+	t.Run("configMap with mountPath returns dirMount", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeConfigMap,
+			ConfigMap: &kubeopenv1alpha1.ConfigMapContext{
+				Name: "my-cm",
+			},
+		}
+		_, dm, gm, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "/workspace/config")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gm != nil {
+			t.Fatal("expected no git mount")
+		}
+		if dm == nil {
+			t.Fatal("expected dirMount")
+		}
+		if dm.configMapName != "my-cm" {
+			t.Errorf("dirMount.configMapName = %q, want %q", dm.configMapName, "my-cm")
+		}
+		if dm.dirPath != "/workspace/config" {
+			t.Errorf("dirMount.dirPath = %q, want %q", dm.dirPath, "/workspace/config")
+		}
+	})
+
+	t.Run("configMap all keys without mountPath", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeConfigMap,
+			ConfigMap: &kubeopenv1alpha1.ConfigMapContext{
+				Name: "my-cm",
+			},
+		}
+		content, dm, gm, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dm != nil || gm != nil {
+			t.Fatal("expected no dir/git mounts")
+		}
+		// All keys should be formatted with <file> XML tags, sorted alphabetically
+		if content == "" {
+			t.Fatal("expected non-empty content")
+		}
+		// key1 should come before key2 in sorted order
+		expected1 := `<file name="key1">`
+		expected2 := `<file name="key2">`
+		if !contains(content, expected1) || !contains(content, expected2) {
+			t.Errorf("content missing expected file tags: %s", content)
+		}
+	})
+
+	t.Run("configMap missing key returns error", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeConfigMap,
+			ConfigMap: &kubeopenv1alpha1.ConfigMapContext{
+				Name: "my-cm",
+				Key:  "nonexistent",
+			},
+		}
+		_, _, _, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "")
+		if err == nil {
+			t.Fatal("expected error for missing key")
+		}
+	})
+
+	t.Run("configMap missing with optional=true returns empty", func(t *testing.T) {
+		optional := true
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeConfigMap,
+			ConfigMap: &kubeopenv1alpha1.ConfigMapContext{
+				Name:     "nonexistent-cm",
+				Key:      "key",
+				Optional: &optional,
+			},
+		}
+		content, _, _, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "")
+		if err != nil {
+			t.Fatalf("unexpected error for optional: %v", err)
+		}
+		if content != "" {
+			t.Errorf("expected empty content for optional missing cm, got %q", content)
+		}
+	})
+
+	t.Run("nil configMap returns empty", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type:      kubeopenv1alpha1.ContextTypeConfigMap,
+			ConfigMap: nil,
+		}
+		content, dm, gm, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dm != nil || gm != nil {
+			t.Fatal("expected no mounts")
+		}
+		if content != "" {
+			t.Errorf("expected empty content, got %q", content)
+		}
+	})
+}
+
+func TestResolveContextContentFromReader_Git(t *testing.T) {
+	reader := newFakeReader()
+	ctx := context.Background()
+
+	t.Run("git context returns gitMount", func(t *testing.T) {
+		depth := 2
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeGit,
+			Git: &kubeopenv1alpha1.GitContext{
+				Repository: "https://github.com/example/repo.git",
+				Ref:        "main",
+				Path:       "docs",
+				Depth:      &depth,
+				SecretRef:  &kubeopenv1alpha1.GitSecretReference{Name: "git-secret"},
+			},
+		}
+		_, dm, gm, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "/workspace/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dm != nil {
+			t.Fatal("expected no dir mount")
+		}
+		if gm == nil {
+			t.Fatal("expected gitMount")
+		}
+		if gm.repository != "https://github.com/example/repo.git" {
+			t.Errorf("repository = %q", gm.repository)
+		}
+		if gm.ref != "main" {
+			t.Errorf("ref = %q, want %q", gm.ref, "main")
+		}
+		if gm.repoPath != "docs" {
+			t.Errorf("repoPath = %q, want %q", gm.repoPath, "docs")
+		}
+		if gm.depth != 2 {
+			t.Errorf("depth = %d, want 2", gm.depth)
+		}
+		if gm.secretName != "git-secret" {
+			t.Errorf("secretName = %q, want %q", gm.secretName, "git-secret")
+		}
+		if gm.mountPath != "/workspace/repo" {
+			t.Errorf("mountPath = %q, want %q", gm.mountPath, "/workspace/repo")
+		}
+	})
+
+	t.Run("git context with defaults", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeGit,
+			Git: &kubeopenv1alpha1.GitContext{
+				Repository: "https://github.com/example/repo.git",
+			},
+		}
+		_, _, gm, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "/workspace/git-context")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gm.ref != DefaultGitRef {
+			t.Errorf("ref = %q, want default %q", gm.ref, DefaultGitRef)
+		}
+		if gm.depth != DefaultGitDepth {
+			t.Errorf("depth = %d, want default %d", gm.depth, DefaultGitDepth)
+		}
+	})
+
+	t.Run("git context with sync HotReload", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeGit,
+			Git: &kubeopenv1alpha1.GitContext{
+				Repository: "https://github.com/example/repo.git",
+				Sync: &kubeopenv1alpha1.GitSync{
+					Enabled:  true,
+					Policy:   kubeopenv1alpha1.GitSyncPolicyHotReload,
+					Interval: metav1.Duration{Duration: 10 * time.Minute},
+				},
+			},
+		}
+		_, _, gm, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "/workspace/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !gm.syncEnabled {
+			t.Error("expected syncEnabled = true")
+		}
+		if gm.syncPolicy != kubeopenv1alpha1.GitSyncPolicyHotReload {
+			t.Errorf("syncPolicy = %q, want HotReload", gm.syncPolicy)
+		}
+		if gm.syncInterval != 10*time.Minute {
+			t.Errorf("syncInterval = %v, want 10m", gm.syncInterval)
+		}
+	})
+
+	t.Run("git context sync defaults", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeGit,
+			Git: &kubeopenv1alpha1.GitContext{
+				Repository: "https://github.com/example/repo.git",
+				Sync: &kubeopenv1alpha1.GitSync{
+					Enabled: true,
+				},
+			},
+		}
+		_, _, gm, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "/workspace/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gm.syncPolicy != kubeopenv1alpha1.GitSyncPolicyHotReload {
+			t.Errorf("default syncPolicy = %q, want HotReload", gm.syncPolicy)
+		}
+		if gm.syncInterval != 5*time.Minute {
+			t.Errorf("default syncInterval = %v, want 5m", gm.syncInterval)
+		}
+	})
+
+	t.Run("git context with recurseSubmodules", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeGit,
+			Git: &kubeopenv1alpha1.GitContext{
+				Repository:        "https://github.com/example/repo.git",
+				RecurseSubmodules: true,
+			},
+		}
+		_, _, gm, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "/workspace/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !gm.recurseSubmodules {
+			t.Error("expected recurseSubmodules = true")
+		}
+	})
+
+	t.Run("nil git returns empty", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeGit,
+			Git:  nil,
+		}
+		content, dm, gm, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "/workspace/repo")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if dm != nil || gm != nil {
+			t.Fatal("expected no mounts for nil git")
+		}
+		if content != "" {
+			t.Errorf("expected empty content, got %q", content)
+		}
+	})
+}
+
+func TestResolveContextContentFromReader_Runtime(t *testing.T) {
+	reader := newFakeReader()
+	ctx := context.Background()
+
+	item := &kubeopenv1alpha1.ContextItem{
+		Type: kubeopenv1alpha1.ContextTypeRuntime,
+	}
+	content, dm, gm, err := resolveContextContentFromReader(reader, ctx, "default", "runtime", "/workspace", item, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dm != nil || gm != nil {
+		t.Fatal("expected no mounts for runtime context")
+	}
+	if content != RuntimeSystemPrompt {
+		t.Errorf("content = %q, want RuntimeSystemPrompt", content)
+	}
+}
+
+func TestResolveContextContentFromReader_UnknownType(t *testing.T) {
+	reader := newFakeReader()
+	ctx := context.Background()
+
+	item := &kubeopenv1alpha1.ContextItem{
+		Type: "UnknownType",
+	}
+	_, _, _, err := resolveContextContentFromReader(reader, ctx, "default", "context", "/workspace", item, "")
+	if err == nil {
+		t.Fatal("expected error for unknown context type")
+	}
+}
+
+func TestResolveContextItemFromReader(t *testing.T) {
+	reader := newFakeReader()
+	ctx := context.Background()
+
+	t.Run("git context without mountPath fails", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type: kubeopenv1alpha1.ContextTypeGit,
+			Git: &kubeopenv1alpha1.GitContext{
+				Repository: "https://github.com/example/repo.git",
+			},
+		}
+		_, _, _, err := resolveContextItemFromReader(reader, ctx, item, "default", "/workspace")
+		if err == nil {
+			t.Fatal("expected error for git context without mountPath")
+		}
+	})
+
+	t.Run("text context with mountPath resolves path", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type:      kubeopenv1alpha1.ContextTypeText,
+			Text:      "hello",
+			MountPath: "config.md",
+		}
+		rc, _, _, err := resolveContextItemFromReader(reader, ctx, item, "default", "/workspace")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rc == nil {
+			t.Fatal("expected resolvedContext")
+		}
+		if rc.mountPath != "/workspace/config.md" {
+			t.Errorf("mountPath = %q, want %q", rc.mountPath, "/workspace/config.md")
+		}
+		if rc.ctxType != string(kubeopenv1alpha1.ContextTypeText) {
+			t.Errorf("ctxType = %q, want %q", rc.ctxType, kubeopenv1alpha1.ContextTypeText)
+		}
+	})
+
+	t.Run("runtime context forces empty mountPath", func(t *testing.T) {
+		item := &kubeopenv1alpha1.ContextItem{
+			Type:      kubeopenv1alpha1.ContextTypeRuntime,
+			MountPath: "should-be-ignored",
+		}
+		rc, _, _, err := resolveContextItemFromReader(reader, ctx, item, "default", "/workspace")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rc.mountPath != "" {
+			t.Errorf("runtime mountPath should be empty, got %q", rc.mountPath)
+		}
+		if rc.name != "runtime" {
+			t.Errorf("name = %q, want %q", rc.name, "runtime")
+		}
+	})
+
+	t.Run("text context with fileMode", func(t *testing.T) {
+		mode := int32(0755)
+		item := &kubeopenv1alpha1.ContextItem{
+			Type:      kubeopenv1alpha1.ContextTypeText,
+			Text:      "#!/bin/bash\necho hello",
+			MountPath: "script.sh",
+			FileMode:  &mode,
+		}
+		rc, _, _, err := resolveContextItemFromReader(reader, ctx, item, "default", "/workspace")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rc.fileMode == nil || *rc.fileMode != 0755 {
+			t.Errorf("fileMode = %v, want 0755", rc.fileMode)
+		}
+	})
+}
+
+func TestProcessContextItems(t *testing.T) {
+	reader := newFakeReader(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "default"},
+		Data:       map[string]string{"data.txt": "config data"},
+	})
+	ctx := context.Background()
+
+	t.Run("empty items returns empty slices", func(t *testing.T) {
+		resolved, dirMounts, gitMounts, err := processContextItems(reader, ctx, nil, "default", "/workspace")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resolved) != 0 || len(dirMounts) != 0 || len(gitMounts) != 0 {
+			t.Error("expected empty slices for nil items")
+		}
+	})
+
+	t.Run("mixed context types", func(t *testing.T) {
+		items := []kubeopenv1alpha1.ContextItem{
+			{
+				Type: kubeopenv1alpha1.ContextTypeText,
+				Text: "text content",
+			},
+			{
+				Type: kubeopenv1alpha1.ContextTypeConfigMap,
+				ConfigMap: &kubeopenv1alpha1.ConfigMapContext{
+					Name: "test-cm",
+				},
+				MountPath: "/workspace/configs",
+			},
+			{
+				Type: kubeopenv1alpha1.ContextTypeGit,
+				Git: &kubeopenv1alpha1.GitContext{
+					Repository: "https://github.com/example/repo.git",
+				},
+				MountPath: "/workspace/repo",
+			},
+		}
+		resolved, dirMounts, gitMounts, err := processContextItems(reader, ctx, items, "default", "/workspace")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resolved) != 1 {
+			t.Errorf("resolved count = %d, want 1 (text)", len(resolved))
+		}
+		if len(dirMounts) != 1 {
+			t.Errorf("dirMounts count = %d, want 1 (configMap)", len(dirMounts))
+		}
+		if len(gitMounts) != 1 {
+			t.Errorf("gitMounts count = %d, want 1 (git)", len(gitMounts))
+		}
+	})
+
+	t.Run("error propagation", func(t *testing.T) {
+		items := []kubeopenv1alpha1.ContextItem{
+			{
+				Type: "InvalidType",
+			},
+		}
+		_, _, _, err := processContextItems(reader, ctx, items, "default", "/workspace")
+		if err == nil {
+			t.Fatal("expected error for invalid context type")
+		}
+	})
+}
+
+func TestBuildContextConfigMapData(t *testing.T) {
+	t.Run("contexts with mountPath become file mounts", func(t *testing.T) {
+		resolved := []resolvedContext{
+			{
+				name:      "context",
+				namespace: "default",
+				ctxType:   "Text",
+				content:   "file content",
+				mountPath: "/workspace/file.md",
+			},
+		}
+		data, fileMounts := buildContextConfigMapData(resolved, "/workspace")
+		if len(data) != 1 {
+			t.Fatalf("expected 1 ConfigMap entry, got %d", len(data))
+		}
+		key := sanitizeConfigMapKey("/workspace/file.md")
+		if data[key] != "file content" {
+			t.Errorf("ConfigMap data[%s] = %q, want %q", key, data[key], "file content")
+		}
+		if len(fileMounts) != 1 {
+			t.Fatalf("expected 1 file mount, got %d", len(fileMounts))
+		}
+		if fileMounts[0].filePath != "/workspace/file.md" {
+			t.Errorf("fileMount path = %q, want %q", fileMounts[0].filePath, "/workspace/file.md")
+		}
+	})
+
+	t.Run("contexts without mountPath aggregated to context.md", func(t *testing.T) {
+		resolved := []resolvedContext{
+			{
+				name:      "instructions",
+				namespace: "default",
+				ctxType:   "Text",
+				content:   "some instructions",
+			},
+			{
+				name:      "runtime",
+				namespace: "default",
+				ctxType:   "Runtime",
+				content:   "runtime info",
+			},
+		}
+		data, fileMounts := buildContextConfigMapData(resolved, "/workspace")
+
+		contextFileKey := sanitizeConfigMapKey("/workspace/" + ContextFileRelPath)
+		if _, ok := data[contextFileKey]; !ok {
+			t.Fatalf("expected context file key %s in ConfigMap data", contextFileKey)
+		}
+		content := data[contextFileKey]
+		if !contains(content, `<context name="instructions"`) {
+			t.Errorf("missing instructions context tag in %s", content)
+		}
+		if !contains(content, `<context name="runtime"`) {
+			t.Errorf("missing runtime context tag in %s", content)
+		}
+
+		// context file should be in fileMounts
+		found := false
+		for _, fm := range fileMounts {
+			if fm.filePath == "/workspace/"+ContextFileRelPath {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected context file in fileMounts")
+		}
+	})
+
+	t.Run("fileMode preserved in file mounts", func(t *testing.T) {
+		mode := int32(0755)
+		resolved := []resolvedContext{
+			{
+				content:   "script",
+				mountPath: "/workspace/run.sh",
+				fileMode:  &mode,
+			},
+		}
+		_, fileMounts := buildContextConfigMapData(resolved, "/workspace")
+		if len(fileMounts) != 1 {
+			t.Fatalf("expected 1 file mount, got %d", len(fileMounts))
+		}
+		if fileMounts[0].fileMode == nil || *fileMounts[0].fileMode != 0755 {
+			t.Errorf("fileMode not preserved: %v", fileMounts[0].fileMode)
+		}
+	})
+
+	t.Run("empty resolved contexts produce no data", func(t *testing.T) {
+		data, fileMounts := buildContextConfigMapData(nil, "/workspace")
+		if len(data) != 0 {
+			t.Errorf("expected empty data, got %d entries", len(data))
+		}
+		if len(fileMounts) != 0 {
+			t.Errorf("expected no fileMounts, got %d", len(fileMounts))
+		}
+	})
+}
+
+func TestServerContextConfigMapName(t *testing.T) {
+	name := ServerContextConfigMapName("my-agent")
+	if name != "my-agent-server-context" {
+		t.Errorf("ServerContextConfigMapName = %q, want %q", name, "my-agent-server-context")
+	}
+}
+
+func TestBuildServerContextConfigMap(t *testing.T) {
+	agent := &kubeopenv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+	}
+
+	t.Run("nil data returns nil", func(t *testing.T) {
+		cm := BuildServerContextConfigMap(agent, nil)
+		if cm != nil {
+			t.Error("expected nil ConfigMap for nil data")
+		}
+	})
+
+	t.Run("empty data returns nil", func(t *testing.T) {
+		cm := BuildServerContextConfigMap(agent, map[string]string{})
+		if cm != nil {
+			t.Error("expected nil ConfigMap for empty data")
+		}
+	})
+
+	t.Run("returns ConfigMap with correct metadata", func(t *testing.T) {
+		data := map[string]string{"key": "value"}
+		cm := BuildServerContextConfigMap(agent, data)
+		if cm == nil {
+			t.Fatal("expected non-nil ConfigMap")
+		}
+		if cm.Name != "test-agent-server-context" {
+			t.Errorf("name = %q, want %q", cm.Name, "test-agent-server-context")
+		}
+		if cm.Namespace != "default" {
+			t.Errorf("namespace = %q, want %q", cm.Namespace, "default")
+		}
+		if cm.Labels["app"] != "kubeopencode" {
+			t.Errorf("label app = %q, want kubeopencode", cm.Labels["app"])
+		}
+		if cm.Labels[AgentLabelKey] != "test-agent" {
+			t.Errorf("label agent = %q, want test-agent", cm.Labels[AgentLabelKey])
+		}
+		if cm.Data["key"] != "value" {
+			t.Errorf("data[key] = %q, want value", cm.Data["key"])
+		}
+	})
+}
+
+func TestGetConfigMapKeyFromReader(t *testing.T) {
+	reader := newFakeReader(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "ns"},
+		Data:       map[string]string{"key1": "val1"},
+	})
+	ctx := context.Background()
+
+	t.Run("existing key", func(t *testing.T) {
+		content, err := getConfigMapKeyFromReader(reader, ctx, "ns", "test-cm", "key1", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content != "val1" {
+			t.Errorf("content = %q, want val1", content)
+		}
+	})
+
+	t.Run("missing key non-optional", func(t *testing.T) {
+		_, err := getConfigMapKeyFromReader(reader, ctx, "ns", "test-cm", "missing", nil)
+		if err == nil {
+			t.Fatal("expected error for missing key")
+		}
+	})
+
+	t.Run("missing key optional", func(t *testing.T) {
+		optional := true
+		content, err := getConfigMapKeyFromReader(reader, ctx, "ns", "test-cm", "missing", &optional)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content != "" {
+			t.Errorf("expected empty for optional missing key, got %q", content)
+		}
+	})
+
+	t.Run("missing configMap non-optional", func(t *testing.T) {
+		_, err := getConfigMapKeyFromReader(reader, ctx, "ns", "nonexistent", "key", nil)
+		if err == nil {
+			t.Fatal("expected error for missing configMap")
+		}
+	})
+
+	t.Run("missing configMap optional", func(t *testing.T) {
+		optional := true
+		content, err := getConfigMapKeyFromReader(reader, ctx, "ns", "nonexistent", "key", &optional)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content != "" {
+			t.Errorf("expected empty for optional missing cm, got %q", content)
+		}
+	})
+}
+
+func TestGetConfigMapAllKeysFromReader(t *testing.T) {
+	reader := newFakeReader(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "multi-cm", Namespace: "ns"},
+		Data:       map[string]string{"b.txt": "beta", "a.txt": "alpha"},
+	})
+	ctx := context.Background()
+
+	t.Run("all keys sorted with XML tags", func(t *testing.T) {
+		content, err := getConfigMapAllKeysFromReader(reader, ctx, "ns", "multi-cm", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// a.txt should come before b.txt
+		if !contains(content, `<file name="a.txt">`) || !contains(content, `<file name="b.txt">`) {
+			t.Errorf("missing file tags in: %s", content)
+		}
+		if !contains(content, "alpha") || !contains(content, "beta") {
+			t.Errorf("missing content in: %s", content)
+		}
+	})
+
+	t.Run("empty configMap returns empty", func(t *testing.T) {
+		emptyReader := newFakeReader(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "empty-cm", Namespace: "ns"},
+			Data:       map[string]string{},
+		})
+		content, err := getConfigMapAllKeysFromReader(emptyReader, ctx, "ns", "empty-cm", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content != "" {
+			t.Errorf("expected empty, got %q", content)
+		}
+	})
+}
+
+// contains is a helper to check substring presence.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
+}
+
+func containsSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/crontask_controller_test.go
+++ b/internal/controller/crontask_controller_test.go
@@ -363,6 +363,102 @@ var _ = Describe("CronTaskController", func() {
 		})
 	})
 
+	Context("ConcurrencyPolicy Replace", func() {
+		It("Should stop active Tasks when a new scheduled Task is created", func() {
+			cronTaskName := fmt.Sprintf("ct-replace-%d", time.Now().UnixNano())
+			cronTask := newCronTask(cronTaskName, everyMinuteSchedule)
+			cronTask.Spec.ConcurrencyPolicy = kubeopenv1alpha1.ReplaceConcurrent
+
+			By("Creating the CronTask with everyMinuteSchedule")
+			Expect(k8sClient.Create(ctx, cronTask)).Should(Succeed())
+
+			By("Waiting for the first child Task to be created via schedule")
+			taskList := &kubeopenv1alpha1.TaskList{}
+			Eventually(func() int {
+				if err := k8sClient.List(ctx, taskList,
+					client.InNamespace(cronTaskNamespace),
+					client.MatchingLabels{kubeopenv1alpha1.CronTaskLabelKey: cronTaskName},
+				); err != nil {
+					return 0
+				}
+				return len(taskList.Items)
+			}, cronTaskTimeout, interval).Should(BeNumerically(">=", 1))
+
+			firstTaskName := taskList.Items[0].Name
+
+			By("Waiting for the second child Task via next schedule (Replace should stop the first)")
+			Eventually(func() int {
+				if err := k8sClient.List(ctx, taskList,
+					client.InNamespace(cronTaskNamespace),
+					client.MatchingLabels{kubeopenv1alpha1.CronTaskLabelKey: cronTaskName},
+				); err != nil {
+					return 0
+				}
+				return len(taskList.Items)
+			}, cronTaskTimeout, interval).Should(BeNumerically(">=", 2))
+
+			By("Verifying the first Task has stop annotation from Replace policy")
+			firstTask := &kubeopenv1alpha1.Task{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: firstTaskName, Namespace: cronTaskNamespace}, firstTask); err != nil {
+					return false
+				}
+				return firstTask.Annotations != nil && firstTask.Annotations["kubeopencode.io/stop"] == "true"
+			}, cronTaskTimeout, interval).Should(BeTrue())
+
+			By("Cleaning up")
+			lookup := types.NamespacedName{Name: cronTaskName, Namespace: cronTaskNamespace}
+			created := &kubeopenv1alpha1.CronTask{}
+			Expect(k8sClient.Get(ctx, lookup, created)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, created)).Should(Succeed())
+		})
+	})
+
+	Context("ConcurrencyPolicy Allow", func() {
+		It("Should allow multiple Tasks to run concurrently", func() {
+			cronTaskName := fmt.Sprintf("ct-allow-%d", time.Now().UnixNano())
+			cronTask := newCronTask(cronTaskName, everyMinuteSchedule)
+			cronTask.Spec.ConcurrencyPolicy = kubeopenv1alpha1.AllowConcurrent
+
+			By("Creating the CronTask with everyMinuteSchedule")
+			Expect(k8sClient.Create(ctx, cronTask)).Should(Succeed())
+
+			By("Waiting for the first child Task via schedule")
+			taskList := &kubeopenv1alpha1.TaskList{}
+			Eventually(func() int {
+				if err := k8sClient.List(ctx, taskList,
+					client.InNamespace(cronTaskNamespace),
+					client.MatchingLabels{kubeopenv1alpha1.CronTaskLabelKey: cronTaskName},
+				); err != nil {
+					return 0
+				}
+				return len(taskList.Items)
+			}, cronTaskTimeout, interval).Should(BeNumerically(">=", 1))
+
+			By("Waiting for the second child Task via next schedule (Allow should keep the first running)")
+			Eventually(func() int {
+				if err := k8sClient.List(ctx, taskList,
+					client.InNamespace(cronTaskNamespace),
+					client.MatchingLabels{kubeopenv1alpha1.CronTaskLabelKey: cronTaskName},
+				); err != nil {
+					return 0
+				}
+				return len(taskList.Items)
+			}, cronTaskTimeout, interval).Should(BeNumerically(">=", 2))
+
+			By("Verifying no Tasks have stop annotation (Allow policy)")
+			for _, task := range taskList.Items {
+				Expect(task.Annotations).ShouldNot(HaveKey("kubeopencode.io/stop"))
+			}
+
+			By("Cleaning up")
+			lookup := types.NamespacedName{Name: cronTaskName, Namespace: cronTaskNamespace}
+			created := &kubeopenv1alpha1.CronTask{}
+			Expect(k8sClient.Get(ctx, lookup, created)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, created)).Should(Succeed())
+		})
+	})
+
 	Context("OwnerReference setup", func() {
 		It("Should set correct ownerReference on child Tasks", func() {
 			cronTaskName := fmt.Sprintf("ct-gc-%d", time.Now().UnixNano())

--- a/internal/controller/crontask_unit_test.go
+++ b/internal/controller/crontask_unit_test.go
@@ -1,0 +1,178 @@
+// Copyright Contributors to the KubeOpenCode project
+
+//go:build !integration
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
+)
+
+func TestCronScheduleWithTZ(t *testing.T) {
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+
+	t.Run("timezone-aware Next", func(t *testing.T) {
+		// Parse "0 9 * * *" (9:00 AM daily)
+		baseSched, err := parser.Parse("0 9 * * *")
+		if err != nil {
+			t.Fatalf("failed to parse schedule: %v", err)
+		}
+
+		loc, err := time.LoadLocation("America/New_York")
+		if err != nil {
+			t.Fatalf("failed to load timezone: %v", err)
+		}
+
+		tzSched := &cronScheduleWithTZ{Schedule: baseSched, loc: loc}
+
+		// Use a known UTC time: 2024-01-15 14:00:00 UTC (= 9:00 AM EST)
+		now := time.Date(2024, 1, 15, 14, 0, 0, 0, time.UTC)
+
+		next := tzSched.Next(now)
+		// Next should be 9:00 AM EST on Jan 16, which is 14:00 UTC Jan 16
+		expectedUTC := time.Date(2024, 1, 16, 14, 0, 0, 0, time.UTC)
+		if !next.Equal(expectedUTC) {
+			t.Errorf("Next() = %v, want %v (9 AM EST on Jan 16 = 14:00 UTC)", next, expectedUTC)
+		}
+	})
+
+	t.Run("UTC schedule (no timezone wrapper)", func(t *testing.T) {
+		sched, err := parser.Parse("0 9 * * *")
+		if err != nil {
+			t.Fatalf("failed to parse: %v", err)
+		}
+
+		now := time.Date(2024, 1, 15, 8, 0, 0, 0, time.UTC)
+		next := sched.Next(now)
+		expected := time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC)
+		if !next.Equal(expected) {
+			t.Errorf("Next() = %v, want %v", next, expected)
+		}
+	})
+}
+
+func TestGetMostRecentScheduleTime(t *testing.T) {
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	r := &CronTaskReconciler{}
+
+	t.Run("no schedule due yet", func(t *testing.T) {
+		sched, _ := parser.Parse("0 0 1 1 *") // Jan 1 midnight (far future)
+		cronTask := &kubeopenv1alpha1.CronTask{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(time.Now()),
+			},
+		}
+		now := time.Now()
+		scheduled, missed := r.getMostRecentScheduleTime(cronTask, sched, now)
+		if scheduled != nil {
+			t.Errorf("expected nil scheduled time, got %v", scheduled)
+		}
+		if missed != 0 {
+			t.Errorf("expected 0 missed, got %d", missed)
+		}
+	})
+
+	t.Run("one missed schedule", func(t *testing.T) {
+		sched, _ := parser.Parse("* * * * *") // every minute
+		past := time.Now().Add(-2 * time.Minute)
+		cronTask := &kubeopenv1alpha1.CronTask{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(past),
+			},
+		}
+		now := time.Now()
+		scheduled, missed := r.getMostRecentScheduleTime(cronTask, sched, now)
+		if scheduled == nil {
+			t.Fatal("expected non-nil scheduled time")
+		}
+		if missed < 1 {
+			t.Errorf("expected at least 1 missed, got %d", missed)
+		}
+	})
+
+	t.Run("uses lastScheduleTime when set", func(t *testing.T) {
+		sched, _ := parser.Parse("* * * * *") // every minute
+		creation := time.Now().Add(-10 * time.Minute)
+		lastSchedule := time.Now().Add(-1 * time.Minute)
+		cronTask := &kubeopenv1alpha1.CronTask{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(creation),
+			},
+			Status: kubeopenv1alpha1.CronTaskStatus{
+				LastScheduleTime: &metav1.Time{Time: lastSchedule},
+			},
+		}
+		now := time.Now()
+		_, missed := r.getMostRecentScheduleTime(cronTask, sched, now)
+		// With lastSchedule only ~1 minute ago, should have ~1 missed
+		if missed > 3 {
+			t.Errorf("expected <= 3 missed (from lastScheduleTime), got %d", missed)
+		}
+	})
+
+	t.Run("too many missed schedules caps at 101", func(t *testing.T) {
+		sched, _ := parser.Parse("* * * * *") // every minute
+		longAgo := time.Now().Add(-200 * time.Minute)
+		cronTask := &kubeopenv1alpha1.CronTask{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.NewTime(longAgo),
+			},
+		}
+		now := time.Now()
+		_, missed := r.getMostRecentScheduleTime(cronTask, sched, now)
+		if missed < 101 {
+			t.Errorf("expected > 100 missed (safety break), got %d", missed)
+		}
+	})
+}
+
+func TestIsAtRetainedLimit(t *testing.T) {
+	r := &CronTaskReconciler{}
+
+	t.Run("nil maxRetainedTasks never limits", func(t *testing.T) {
+		cronTask := &kubeopenv1alpha1.CronTask{}
+		tasks := make([]kubeopenv1alpha1.Task, 100)
+		if r.isAtRetainedLimit(cronTask, tasks) {
+			t.Error("expected no limit when maxRetainedTasks is nil")
+		}
+	})
+
+	t.Run("under limit", func(t *testing.T) {
+		max := int32(10)
+		cronTask := &kubeopenv1alpha1.CronTask{
+			Spec: kubeopenv1alpha1.CronTaskSpec{MaxRetainedTasks: &max},
+		}
+		tasks := make([]kubeopenv1alpha1.Task, 5)
+		if r.isAtRetainedLimit(cronTask, tasks) {
+			t.Error("expected not at limit with 5/10 tasks")
+		}
+	})
+
+	t.Run("at limit", func(t *testing.T) {
+		max := int32(10)
+		cronTask := &kubeopenv1alpha1.CronTask{
+			Spec: kubeopenv1alpha1.CronTaskSpec{MaxRetainedTasks: &max},
+		}
+		tasks := make([]kubeopenv1alpha1.Task, 10)
+		if !r.isAtRetainedLimit(cronTask, tasks) {
+			t.Error("expected at limit with 10/10 tasks")
+		}
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		max := int32(10)
+		cronTask := &kubeopenv1alpha1.CronTask{
+			Spec: kubeopenv1alpha1.CronTaskSpec{MaxRetainedTasks: &max},
+		}
+		tasks := make([]kubeopenv1alpha1.Task, 15)
+		if !r.isAtRetainedLimit(cronTask, tasks) {
+			t.Error("expected at limit with 15/10 tasks")
+		}
+	})
+}

--- a/internal/controller/pod_builder_test.go
+++ b/internal/controller/pod_builder_test.go
@@ -3164,3 +3164,384 @@ func TestBuildPod_WithExtraVolumesAndMounts(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildPluginInitContainer(t *testing.T) {
+	plugins := []kubeopenv1alpha1.PluginSpec{
+		{Name: "@example/plugin-a"},
+		{Name: "@example/plugin-b"},
+		{Name: "@example/plugin-a"}, // duplicate should be deduped
+	}
+	sysCfg := defaultSystemConfig()
+
+	container := buildPluginInitContainer(plugins, sysCfg)
+
+	if container.Name != "plugin-init" {
+		t.Errorf("name = %q, want plugin-init", container.Name)
+	}
+	if container.Image != DefaultKubeOpenCodeImage {
+		t.Errorf("image = %q, want %q", container.Image, DefaultKubeOpenCodeImage)
+	}
+	if len(container.Command) != 2 || container.Command[1] != "plugin-init" {
+		t.Errorf("command = %v, want [/kubeopencode plugin-init]", container.Command)
+	}
+
+	// Check env vars
+	var pluginPackages, pluginDir string
+	for _, env := range container.Env {
+		switch env.Name {
+		case "PLUGIN_PACKAGES":
+			pluginPackages = env.Value
+		case "PLUGIN_DIR":
+			pluginDir = env.Value
+		}
+	}
+	if pluginDir != DefaultPluginsMountBase {
+		t.Errorf("PLUGIN_DIR = %q, want %q", pluginDir, DefaultPluginsMountBase)
+	}
+	// Should contain 2 packages (deduped)
+	if !strings.Contains(pluginPackages, "@example/plugin-a") || !strings.Contains(pluginPackages, "@example/plugin-b") {
+		t.Errorf("PLUGIN_PACKAGES = %q, missing expected packages", pluginPackages)
+	}
+
+	// Check volume mounts
+	if len(container.VolumeMounts) != 1 || container.VolumeMounts[0].Name != PluginsVolumeName {
+		t.Errorf("expected single volume mount %q, got %v", PluginsVolumeName, container.VolumeMounts)
+	}
+}
+
+func TestBuildPod_WithPlugins(t *testing.T) {
+	task := &kubeopenv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       types.UID("test-uid"),
+		},
+		Spec: kubeopenv1alpha1.TaskSpec{
+			TemplateRef: &kubeopenv1alpha1.AgentTemplateReference{Name: "test-template"},
+		},
+	}
+
+	cfg := agentConfig{
+		agentImage:         "test-opencode:v1.0.0",
+		executorImage:      "test-executor:v1.0.0",
+		workspaceDir:       "/workspace",
+		serviceAccountName: "test-sa",
+		plugins: []kubeopenv1alpha1.PluginSpec{
+			{Name: "@example/my-plugin", Target: "server"},
+		},
+	}
+
+	pod := buildPod(task, "test-task-pod", cfg, nil, nil, nil, nil, defaultSystemConfig(), "")
+
+	// Should have a plugin-init container
+	hasPluginInit := false
+	for _, c := range pod.Spec.InitContainers {
+		if c.Name == "plugin-init" {
+			hasPluginInit = true
+		}
+	}
+	if !hasPluginInit {
+		t.Error("expected plugin-init container")
+	}
+
+	// Should have plugins volume
+	hasPluginsVolume := false
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == PluginsVolumeName {
+			hasPluginsVolume = true
+			if v.EmptyDir == nil {
+				t.Error("plugins volume should be emptyDir")
+			}
+		}
+	}
+	if !hasPluginsVolume {
+		t.Error("expected plugins volume")
+	}
+
+	// Executor container should have plugins volume mount (read-only)
+	executor := pod.Spec.Containers[0]
+	hasPluginsMount := false
+	for _, vm := range executor.VolumeMounts {
+		if vm.Name == PluginsVolumeName {
+			hasPluginsMount = true
+			if !vm.ReadOnly {
+				t.Error("plugins mount on executor should be read-only")
+			}
+			if vm.MountPath != DefaultPluginsMountBase {
+				t.Errorf("plugins mount path = %q, want %q", vm.MountPath, DefaultPluginsMountBase)
+			}
+		}
+	}
+	if !hasPluginsMount {
+		t.Error("expected plugins volume mount on executor")
+	}
+}
+
+func TestBuildPod_WithTUIPlugins(t *testing.T) {
+	task := &kubeopenv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       types.UID("test-uid"),
+		},
+		Spec: kubeopenv1alpha1.TaskSpec{
+			TemplateRef: &kubeopenv1alpha1.AgentTemplateReference{Name: "test-template"},
+		},
+	}
+
+	t.Run("TUI plugin sets OPENCODE_TUI_CONFIG", func(t *testing.T) {
+		cfg := agentConfig{
+			agentImage:         "test-opencode:v1.0.0",
+			executorImage:      "test-executor:v1.0.0",
+			workspaceDir:       "/workspace",
+			serviceAccountName: "test-sa",
+			plugins: []kubeopenv1alpha1.PluginSpec{
+				{Name: "@example/tui-plugin", Target: "tui"},
+			},
+		}
+		pod := buildPod(task, "test-task-pod", cfg, nil, nil, nil, nil, defaultSystemConfig(), "")
+		executor := pod.Spec.Containers[0]
+		hasTUIConfig := false
+		for _, env := range executor.Env {
+			if env.Name == OpenCodeTUIConfigEnvVar {
+				hasTUIConfig = true
+				if env.Value != OpenCodeTUIConfigPath {
+					t.Errorf("OPENCODE_TUI_CONFIG = %q, want %q", env.Value, OpenCodeTUIConfigPath)
+				}
+			}
+		}
+		if !hasTUIConfig {
+			t.Error("expected OPENCODE_TUI_CONFIG env var for TUI plugins")
+		}
+	})
+
+	t.Run("server-only plugins do not set OPENCODE_TUI_CONFIG", func(t *testing.T) {
+		cfg := agentConfig{
+			agentImage:         "test-opencode:v1.0.0",
+			executorImage:      "test-executor:v1.0.0",
+			workspaceDir:       "/workspace",
+			serviceAccountName: "test-sa",
+			plugins: []kubeopenv1alpha1.PluginSpec{
+				{Name: "@example/server-plugin", Target: "server"},
+			},
+		}
+		pod := buildPod(task, "test-task-pod", cfg, nil, nil, nil, nil, defaultSystemConfig(), "")
+		executor := pod.Spec.Containers[0]
+		for _, env := range executor.Env {
+			if env.Name == OpenCodeTUIConfigEnvVar {
+				t.Error("OPENCODE_TUI_CONFIG should not be set for server-only plugins")
+			}
+		}
+	})
+}
+
+func TestBuildPod_WithGitWorkspaceRoot(t *testing.T) {
+	task := &kubeopenv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       types.UID("test-uid"),
+		},
+		Spec: kubeopenv1alpha1.TaskSpec{
+			TemplateRef: &kubeopenv1alpha1.AgentTemplateReference{Name: "test-template"},
+		},
+	}
+
+	t.Run("git context at workspace root uses GIT_WORKSPACE_DIR", func(t *testing.T) {
+		cfg := agentConfig{
+			agentImage:         "test-opencode:v1.0.0",
+			executorImage:      "test-executor:v1.0.0",
+			workspaceDir:       "/workspace",
+			serviceAccountName: "test-sa",
+		}
+		gitMounts := []gitMount{
+			{
+				contextName: "context",
+				repository:  "https://github.com/example/repo.git",
+				ref:         "main",
+				mountPath:   "/workspace", // same as workspaceDir
+				depth:       1,
+			},
+		}
+		pod := buildPod(task, "test-task-pod", cfg, nil, nil, nil, gitMounts, defaultSystemConfig(), "")
+
+		// The git-init container should have GIT_WORKSPACE_DIR env var
+		var gitInit *corev1.Container
+		for i := range pod.Spec.InitContainers {
+			if strings.HasPrefix(pod.Spec.InitContainers[i].Name, "git-init") {
+				gitInit = &pod.Spec.InitContainers[i]
+				break
+			}
+		}
+		if gitInit == nil {
+			t.Fatal("expected git-init container")
+		}
+		hasWorkspaceDir := false
+		for _, env := range gitInit.Env {
+			if env.Name == "GIT_WORKSPACE_DIR" {
+				hasWorkspaceDir = true
+				if env.Value != "/workspace" {
+					t.Errorf("GIT_WORKSPACE_DIR = %q, want /workspace", env.Value)
+				}
+			}
+		}
+		if !hasWorkspaceDir {
+			t.Error("expected GIT_WORKSPACE_DIR env var on git-init for workspace root mount")
+		}
+
+		// Workspace root mounts should have workspace volume on git-init
+		hasWorkspaceMount := false
+		for _, vm := range gitInit.VolumeMounts {
+			if vm.Name == WorkspaceVolumeName && vm.MountPath == "/workspace" {
+				hasWorkspaceMount = true
+			}
+		}
+		if !hasWorkspaceMount {
+			t.Error("expected workspace volume mount on git-init for workspace root merge")
+		}
+
+		// Executor should NOT have a separate git volume mount at /workspace
+		// (only the existing workspace volume)
+		executor := pod.Spec.Containers[0]
+		gitMountOnExecutor := false
+		for _, vm := range executor.VolumeMounts {
+			if strings.HasPrefix(vm.Name, "git-context") && vm.MountPath == "/workspace" {
+				gitMountOnExecutor = true
+			}
+		}
+		if gitMountOnExecutor {
+			t.Error("workspace root git mount should not add a separate volume mount on executor")
+		}
+	})
+
+	t.Run("git context at workspace root with repoPath sets GIT_REPO_SUBPATH", func(t *testing.T) {
+		cfg := agentConfig{
+			agentImage:         "test-opencode:v1.0.0",
+			executorImage:      "test-executor:v1.0.0",
+			workspaceDir:       "/workspace",
+			serviceAccountName: "test-sa",
+		}
+		gitMounts := []gitMount{
+			{
+				contextName: "context",
+				repository:  "https://github.com/example/repo.git",
+				ref:         "main",
+				mountPath:   "/workspace",
+				repoPath:    "src/app",
+				depth:       1,
+			},
+		}
+		pod := buildPod(task, "test-task-pod", cfg, nil, nil, nil, gitMounts, defaultSystemConfig(), "")
+
+		var gitInit *corev1.Container
+		for i := range pod.Spec.InitContainers {
+			if strings.HasPrefix(pod.Spec.InitContainers[i].Name, "git-init") {
+				gitInit = &pod.Spec.InitContainers[i]
+				break
+			}
+		}
+		if gitInit == nil {
+			t.Fatal("expected git-init container")
+		}
+		hasSubpath := false
+		for _, env := range gitInit.Env {
+			if env.Name == "GIT_REPO_SUBPATH" {
+				hasSubpath = true
+				if env.Value != "src/app" {
+					t.Errorf("GIT_REPO_SUBPATH = %q, want src/app", env.Value)
+				}
+			}
+		}
+		if !hasSubpath {
+			t.Error("expected GIT_REPO_SUBPATH env var when repoPath is set")
+		}
+	})
+}
+
+func TestBuildGitInitContainer_WithRecurseSubmodules(t *testing.T) {
+	gm := gitMount{
+		contextName:       "context",
+		repository:        "https://github.com/example/repo.git",
+		ref:               "main",
+		mountPath:         "/workspace/repo",
+		depth:             1,
+		recurseSubmodules: true,
+	}
+	container := buildGitInitContainer(gm, "git-context-0", 0, defaultSystemConfig())
+
+	hasRecurse := false
+	for _, env := range container.Env {
+		if env.Name == "GIT_RECURSE_SUBMODULES" {
+			hasRecurse = true
+			if env.Value != "true" {
+				t.Errorf("GIT_RECURSE_SUBMODULES = %q, want true", env.Value)
+			}
+		}
+	}
+	if !hasRecurse {
+		t.Error("expected GIT_RECURSE_SUBMODULES env var")
+	}
+}
+
+func TestBuildGitInitContainer_WithoutRecurseSubmodules(t *testing.T) {
+	gm := gitMount{
+		contextName:       "context",
+		repository:        "https://github.com/example/repo.git",
+		ref:               "main",
+		mountPath:         "/workspace/repo",
+		depth:             1,
+		recurseSubmodules: false,
+	}
+	container := buildGitInitContainer(gm, "git-context-0", 0, defaultSystemConfig())
+
+	for _, env := range container.Env {
+		if env.Name == "GIT_RECURSE_SUBMODULES" {
+			t.Error("GIT_RECURSE_SUBMODULES should not be set when recurseSubmodules is false")
+		}
+	}
+}
+
+func TestApplySystemDefaults(t *testing.T) {
+	t.Run("agent proxy nil inherits system proxy", func(t *testing.T) {
+		cfg := agentConfig{}
+		sys := systemConfig{
+			proxy: &kubeopenv1alpha1.ProxyConfig{
+				HttpProxy:  "http://proxy:8080",
+				HttpsProxy: "http://proxy:8443",
+			},
+		}
+		cfg.applySystemDefaults(sys)
+		if cfg.proxy == nil {
+			t.Fatal("expected proxy to be inherited from system")
+		}
+		if cfg.proxy.HttpProxy != "http://proxy:8080" {
+			t.Errorf("HttpProxy = %q, want http://proxy:8080", cfg.proxy.HttpProxy)
+		}
+	})
+
+	t.Run("agent proxy overrides system proxy", func(t *testing.T) {
+		cfg := agentConfig{
+			proxy: &kubeopenv1alpha1.ProxyConfig{
+				HttpProxy: "http://agent-proxy:9090",
+			},
+		}
+		sys := systemConfig{
+			proxy: &kubeopenv1alpha1.ProxyConfig{
+				HttpProxy: "http://system-proxy:8080",
+			},
+		}
+		cfg.applySystemDefaults(sys)
+		if cfg.proxy.HttpProxy != "http://agent-proxy:9090" {
+			t.Errorf("HttpProxy = %q, agent proxy should take precedence", cfg.proxy.HttpProxy)
+		}
+	})
+
+	t.Run("no system proxy leaves agent proxy nil", func(t *testing.T) {
+		cfg := agentConfig{}
+		sys := systemConfig{}
+		cfg.applySystemDefaults(sys)
+		if cfg.proxy != nil {
+			t.Error("proxy should remain nil when no system proxy")
+		}
+	})
+}

--- a/internal/controller/server_builder_test.go
+++ b/internal/controller/server_builder_test.go
@@ -2119,3 +2119,183 @@ func TestBuildServerDeployment_WithoutExtraVolumes(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildServerDeployment_WithPlugins(t *testing.T) {
+	agent := &kubeopenv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+		Spec: kubeopenv1alpha1.AgentSpec{
+			Port: 4096,
+		},
+	}
+
+	cfg := agentConfig{
+		executorImage: "test-executor:v1.0.0",
+		agentImage:    "test-agent:v1.0.0",
+		workspaceDir:  "/workspace",
+		plugins: []kubeopenv1alpha1.PluginSpec{
+			{Name: "@example/my-plugin", Target: "server"},
+		},
+	}
+
+	deployment := BuildServerDeployment(agent, cfg, defaultSystemConfig(), nil, nil, nil, nil, nil)
+	podSpec := deployment.Spec.Template.Spec
+
+	// Should have plugin-init container
+	hasPluginInit := false
+	for _, c := range podSpec.InitContainers {
+		if c.Name == "plugin-init" {
+			hasPluginInit = true
+		}
+	}
+	if !hasPluginInit {
+		t.Error("expected plugin-init container in Deployment")
+	}
+
+	// Should have plugins volume
+	hasPluginsVolume := false
+	for _, v := range podSpec.Volumes {
+		if v.Name == PluginsVolumeName {
+			hasPluginsVolume = true
+		}
+	}
+	if !hasPluginsVolume {
+		t.Error("expected plugins volume in Deployment")
+	}
+
+	// Main container should have plugins mount (read-only)
+	mainContainer := podSpec.Containers[0]
+	hasPluginsMount := false
+	for _, vm := range mainContainer.VolumeMounts {
+		if vm.Name == PluginsVolumeName {
+			hasPluginsMount = true
+			if !vm.ReadOnly {
+				t.Error("plugins mount should be read-only on main container")
+			}
+		}
+	}
+	if !hasPluginsMount {
+		t.Error("expected plugins volume mount on main container")
+	}
+}
+
+func TestBuildServerDeployment_WithTUIPlugins(t *testing.T) {
+	agent := &kubeopenv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+		Spec: kubeopenv1alpha1.AgentSpec{
+			Port: 4096,
+		},
+	}
+
+	t.Run("TUI plugin sets OPENCODE_TUI_CONFIG", func(t *testing.T) {
+		cfg := agentConfig{
+			executorImage: "test-executor:v1.0.0",
+			agentImage:    "test-agent:v1.0.0",
+			workspaceDir:  "/workspace",
+			plugins: []kubeopenv1alpha1.PluginSpec{
+				{Name: "@example/tui-plugin", Target: "tui"},
+			},
+		}
+		deployment := BuildServerDeployment(agent, cfg, defaultSystemConfig(), nil, nil, nil, nil, nil)
+		mainContainer := deployment.Spec.Template.Spec.Containers[0]
+		hasTUIConfig := false
+		for _, env := range mainContainer.Env {
+			if env.Name == OpenCodeTUIConfigEnvVar {
+				hasTUIConfig = true
+				if env.Value != OpenCodeTUIConfigPath {
+					t.Errorf("OPENCODE_TUI_CONFIG = %q, want %q", env.Value, OpenCodeTUIConfigPath)
+				}
+			}
+		}
+		if !hasTUIConfig {
+			t.Error("expected OPENCODE_TUI_CONFIG for TUI plugins")
+		}
+	})
+
+	t.Run("server-only plugins do not set OPENCODE_TUI_CONFIG", func(t *testing.T) {
+		cfg := agentConfig{
+			executorImage: "test-executor:v1.0.0",
+			agentImage:    "test-agent:v1.0.0",
+			workspaceDir:  "/workspace",
+			plugins: []kubeopenv1alpha1.PluginSpec{
+				{Name: "@example/server-plugin", Target: "server"},
+			},
+		}
+		deployment := BuildServerDeployment(agent, cfg, defaultSystemConfig(), nil, nil, nil, nil, nil)
+		mainContainer := deployment.Spec.Template.Spec.Containers[0]
+		for _, env := range mainContainer.Env {
+			if env.Name == OpenCodeTUIConfigEnvVar {
+				t.Error("OPENCODE_TUI_CONFIG should not be set for server-only plugins")
+			}
+		}
+	})
+}
+
+func TestBuildServerDeployment_WithGitWorkspaceRoot(t *testing.T) {
+	agent := &kubeopenv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "default",
+		},
+		Spec: kubeopenv1alpha1.AgentSpec{
+			Port: 4096,
+		},
+	}
+
+	cfg := agentConfig{
+		executorImage: "test-executor:v1.0.0",
+		agentImage:    "test-agent:v1.0.0",
+		workspaceDir:  "/workspace",
+	}
+
+	gitMounts := []gitMount{
+		{
+			contextName: "context",
+			repository:  "https://github.com/example/repo.git",
+			ref:         "main",
+			mountPath:   "/workspace", // same as workspaceDir
+			depth:       1,
+		},
+	}
+
+	deployment := BuildServerDeployment(agent, cfg, defaultSystemConfig(), nil, nil, nil, gitMounts, nil)
+	podSpec := deployment.Spec.Template.Spec
+
+	// git-init container should have GIT_WORKSPACE_DIR
+	var gitInit *corev1.Container
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].Name == "git-init-0" {
+			gitInit = &podSpec.InitContainers[i]
+			break
+		}
+	}
+	if gitInit == nil {
+		t.Fatal("expected git-init-0 container")
+	}
+
+	hasWorkspaceDir := false
+	for _, env := range gitInit.Env {
+		if env.Name == "GIT_WORKSPACE_DIR" {
+			hasWorkspaceDir = true
+			if env.Value != "/workspace" {
+				t.Errorf("GIT_WORKSPACE_DIR = %q, want /workspace", env.Value)
+			}
+		}
+	}
+	if !hasWorkspaceDir {
+		t.Error("expected GIT_WORKSPACE_DIR on git-init for workspace root mount")
+	}
+
+	// Should NOT have separate git volume mount on main container at /workspace
+	mainContainer := podSpec.Containers[0]
+	for _, vm := range mainContainer.VolumeMounts {
+		if vm.Name == "git-context-0" && vm.MountPath == "/workspace" {
+			t.Error("workspace root git mount should not add separate volume mount on main container")
+		}
+	}
+}

--- a/internal/server/handlers/agent_handler_test.go
+++ b/internal/server/handlers/agent_handler_test.go
@@ -1,0 +1,457 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
+	"github.com/kubeopencode/kubeopencode/internal/server/types"
+)
+
+func TestAgentHandler_ListAll(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		wantTotal  int
+		wantStatus int
+	}{
+		{
+			name: "returns agents across namespaces",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "agent-1", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.AgentSpec{WorkspaceDir: "/workspace"},
+				},
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "agent-2", Namespace: "production"},
+					Spec:       kubeopenv1alpha1.AgentSpec{WorkspaceDir: "/workspace"},
+				},
+			},
+			wantTotal:  2,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "returns empty list",
+			objects:    []runtime.Object{},
+			wantTotal:  0,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewAgentHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/agents", nil)
+			r.URL = &url.URL{Path: "/api/v1/agents"}
+
+			handler.ListAll(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			var resp types.AgentListResponse
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			if resp.Total != tt.wantTotal {
+				t.Errorf("expected total %d, got %d", tt.wantTotal, resp.Total)
+			}
+
+			if resp.Pagination == nil {
+				t.Fatal("expected non-nil pagination")
+			}
+		})
+	}
+}
+
+func TestAgentHandler_Get(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespace  string
+		agentName  string
+		objects    []runtime.Object
+		wantStatus int
+	}{
+		{
+			name:      "returns agent",
+			namespace: "default",
+			agentName: "my-agent",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+					Spec: kubeopenv1alpha1.AgentSpec{
+						WorkspaceDir:       "/workspace",
+						ServiceAccountName: "sa",
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "handles not found",
+			namespace:  "default",
+			agentName:  "missing",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewAgentHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", tt.namespace)
+			rctx.URLParams.Add("name", tt.agentName)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Get(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var resp types.AgentResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Name != tt.agentName {
+					t.Errorf("expected name %q, got %q", tt.agentName, resp.Name)
+				}
+				if resp.Namespace != tt.namespace {
+					t.Errorf("expected namespace %q, got %q", tt.namespace, resp.Namespace)
+				}
+				if resp.WorkspaceDir != "/workspace" {
+					t.Errorf("expected workspaceDir %q, got %q", "/workspace", resp.WorkspaceDir)
+				}
+			}
+		})
+	}
+}
+
+func TestAgentHandler_Create(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       interface{}
+		wantStatus int
+	}{
+		{
+			name: "creates agent",
+			body: types.CreateAgentRequest{
+				Name:               "new-agent",
+				WorkspaceDir:       "/workspace",
+				ServiceAccountName: "sa",
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "creates agent with templateRef (no workspaceDir/sa required)",
+			body: types.CreateAgentRequest{
+				Name:        "tmpl-agent",
+				TemplateRef: &types.AgentReference{Name: "my-template"},
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "validates name required",
+			body: types.CreateAgentRequest{
+				WorkspaceDir:       "/workspace",
+				ServiceAccountName: "sa",
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "validates workspaceDir required without template",
+			body: types.CreateAgentRequest{
+				Name:               "no-ws",
+				ServiceAccountName: "sa",
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "validates serviceAccountName required without template",
+			body: types.CreateAgentRequest{
+				Name:         "no-sa",
+				WorkspaceDir: "/workspace",
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+			handler := NewAgentHandler(k8sClient)
+
+			bodyBytes, _ := json.Marshal(tt.body)
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(bodyBytes))
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", "default")
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Create(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusCreated {
+				var resp types.AgentResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Namespace != "default" {
+					t.Errorf("expected namespace %q, got %q", "default", resp.Namespace)
+				}
+			}
+		})
+	}
+}
+
+func TestAgentHandler_Suspend(t *testing.T) {
+	tests := []struct {
+		name       string
+		agentName  string
+		objects    []runtime.Object
+		wantStatus int
+	}{
+		{
+			name:      "suspends agent",
+			agentName: "my-agent",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+					Spec: kubeopenv1alpha1.AgentSpec{
+						WorkspaceDir: "/workspace",
+						Suspend:      false,
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "handles not found",
+			agentName:  "missing",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewAgentHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", nil)
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", "default")
+			rctx.URLParams.Add("name", tt.agentName)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Suspend(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				// Verify the agent spec was updated
+				var agent kubeopenv1alpha1.Agent
+				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: tt.agentName}, &agent); err != nil {
+					t.Fatalf("failed to get agent: %v", err)
+				}
+				if !agent.Spec.Suspend {
+					t.Error("expected agent.Spec.Suspend to be true")
+				}
+
+				// Verify response reflects suspended state
+				var resp types.AgentResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.ServerStatus == nil {
+					t.Fatal("expected non-nil ServerStatus")
+				}
+				if !resp.ServerStatus.Suspended {
+					t.Error("expected response ServerStatus.Suspended to be true")
+				}
+			}
+		})
+	}
+}
+
+func TestAgentHandler_Resume(t *testing.T) {
+	tests := []struct {
+		name       string
+		agentName  string
+		objects    []runtime.Object
+		wantStatus int
+	}{
+		{
+			name:      "resumes agent",
+			agentName: "my-agent",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+					Spec: kubeopenv1alpha1.AgentSpec{
+						WorkspaceDir: "/workspace",
+						Suspend:      true,
+					},
+					Status: kubeopenv1alpha1.AgentStatus{
+						Suspended: true,
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "handles not found",
+			agentName:  "missing",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				WithStatusSubresource(&kubeopenv1alpha1.Agent{}).
+				Build()
+			handler := NewAgentHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", nil)
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", "default")
+			rctx.URLParams.Add("name", tt.agentName)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Resume(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				// Verify the agent spec was updated
+				var agent kubeopenv1alpha1.Agent
+				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: tt.agentName}, &agent); err != nil {
+					t.Fatalf("failed to get agent: %v", err)
+				}
+				if agent.Spec.Suspend {
+					t.Error("expected agent.Spec.Suspend to be false")
+				}
+
+				// Verify response reflects resumed state
+				var resp types.AgentResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.ServerStatus == nil {
+					t.Fatal("expected non-nil ServerStatus")
+				}
+				if resp.ServerStatus.Suspended {
+					t.Error("expected response ServerStatus.Suspended to be false")
+				}
+			}
+		})
+	}
+}
+
+func TestAgentHandler_Suspend_RejectsWithActiveTasks(t *testing.T) {
+	scheme := newTestScheme()
+	agentName := "busy-agent"
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(
+			&kubeopenv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{Name: agentName, Namespace: "default"},
+				Spec: kubeopenv1alpha1.AgentSpec{
+					WorkspaceDir: "/workspace",
+				},
+			},
+			&kubeopenv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "running-task",
+					Namespace: "default",
+					Labels:    map[string]string{"kubeopencode.io/agent": agentName},
+				},
+				Spec: kubeopenv1alpha1.TaskSpec{
+					AgentRef: &kubeopenv1alpha1.AgentReference{Name: agentName},
+				},
+				Status: kubeopenv1alpha1.TaskExecutionStatus{
+					Phase: kubeopenv1alpha1.TaskPhaseRunning,
+				},
+			},
+		).
+		WithStatusSubresource(&kubeopenv1alpha1.Task{}).
+		Build()
+
+	handler := NewAgentHandler(k8sClient)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
+	r.URL = &url.URL{Path: "/"}
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("namespace", "default")
+	rctx.URLParams.Add("name", agentName)
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	handler.Suspend(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusConflict, w.Code, w.Body.String())
+	}
+}

--- a/internal/server/handlers/agenttemplate_handler_test.go
+++ b/internal/server/handlers/agenttemplate_handler_test.go
@@ -1,0 +1,290 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
+	"github.com/kubeopencode/kubeopencode/internal/server/types"
+)
+
+func TestAgentTemplateHandler_ListAll(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		wantTotal  int
+		wantStatus int
+	}{
+		{
+			name: "returns templates across namespaces",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.AgentTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "tmpl-1", Namespace: "default"},
+					Spec: kubeopenv1alpha1.AgentTemplateSpec{
+						WorkspaceDir: "/workspace",
+					},
+				},
+				&kubeopenv1alpha1.AgentTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "tmpl-2", Namespace: "production"},
+					Spec: kubeopenv1alpha1.AgentTemplateSpec{
+						WorkspaceDir: "/workspace",
+					},
+				},
+			},
+			wantTotal:  2,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "returns empty list",
+			objects:    []runtime.Object{},
+			wantTotal:  0,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewAgentTemplateHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/agenttemplates", nil)
+			r.URL = &url.URL{Path: "/api/v1/agenttemplates"}
+
+			handler.ListAll(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			var resp types.AgentTemplateListResponse
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			if resp.Total != tt.wantTotal {
+				t.Errorf("expected total %d, got %d", tt.wantTotal, resp.Total)
+			}
+
+			if resp.Pagination == nil {
+				t.Fatal("expected non-nil pagination")
+			}
+		})
+	}
+}
+
+func TestAgentTemplateHandler_Get(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespace  string
+		tmplName   string
+		objects    []runtime.Object
+		wantStatus int
+	}{
+		{
+			name:      "returns template",
+			namespace: "default",
+			tmplName:  "my-tmpl",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.AgentTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-tmpl", Namespace: "default"},
+					Spec: kubeopenv1alpha1.AgentTemplateSpec{
+						WorkspaceDir:       "/workspace",
+						ServiceAccountName: "sa",
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "handles not found",
+			namespace:  "default",
+			tmplName:   "missing",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewAgentTemplateHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", tt.namespace)
+			rctx.URLParams.Add("name", tt.tmplName)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Get(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var resp types.AgentTemplateResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Name != tt.tmplName {
+					t.Errorf("expected name %q, got %q", tt.tmplName, resp.Name)
+				}
+				if resp.Namespace != tt.namespace {
+					t.Errorf("expected namespace %q, got %q", tt.namespace, resp.Namespace)
+				}
+				if resp.WorkspaceDir != "/workspace" {
+					t.Errorf("expected workspaceDir %q, got %q", "/workspace", resp.WorkspaceDir)
+				}
+			}
+		})
+	}
+}
+
+func TestAgentTemplateHandler_Create(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       interface{}
+		wantStatus int
+	}{
+		{
+			name: "creates template",
+			body: types.CreateAgentTemplateRequest{
+				Name:               "new-tmpl",
+				WorkspaceDir:       "/workspace",
+				ServiceAccountName: "sa",
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "validates name required",
+			body: types.CreateAgentTemplateRequest{
+				WorkspaceDir: "/workspace",
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+			handler := NewAgentTemplateHandler(k8sClient)
+
+			bodyBytes, _ := json.Marshal(tt.body)
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(bodyBytes))
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", "default")
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Create(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusCreated {
+				var resp types.AgentTemplateResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Namespace != "default" {
+					t.Errorf("expected namespace %q, got %q", "default", resp.Namespace)
+				}
+			}
+		})
+	}
+}
+
+func TestAgentTemplateHandler_Delete(t *testing.T) {
+	tests := []struct {
+		name       string
+		tmplName   string
+		objects    []runtime.Object
+		wantStatus int
+	}{
+		{
+			name:     "deletes template",
+			tmplName: "my-tmpl",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.AgentTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-tmpl", Namespace: "default"},
+					Spec: kubeopenv1alpha1.AgentTemplateSpec{
+						WorkspaceDir: "/workspace",
+					},
+				},
+			},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "handles not found",
+			tmplName:   "missing",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewAgentTemplateHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodDelete, "/", nil)
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", "default")
+			rctx.URLParams.Add("name", tt.tmplName)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Delete(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			// Verify deletion
+			if tt.wantStatus == http.StatusNoContent {
+				var tmpl kubeopenv1alpha1.AgentTemplate
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: tt.tmplName}, &tmpl)
+				if err == nil {
+					t.Error("expected template to be deleted")
+				}
+			}
+		})
+	}
+}

--- a/internal/server/handlers/config_handler_test.go
+++ b/internal/server/handlers/config_handler_test.go
@@ -1,0 +1,166 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
+	"github.com/kubeopencode/kubeopencode/internal/server/types"
+)
+
+func TestConfigHandler_Get(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		wantStatus int
+		wantName   string
+	}{
+		{
+			name: "returns config response",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.KubeOpenCodeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: kubeopenv1alpha1.KubeOpenCodeConfigSpec{
+						Cleanup: &kubeopenv1alpha1.CleanupConfig{
+							TTLSecondsAfterFinished: int32Ptr(3600),
+						},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+			wantName:   "cluster",
+		},
+		{
+			name:       "handles not found",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewConfigHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/config", nil)
+			r.URL = &url.URL{Path: "/api/v1/config"}
+
+			handler.Get(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var resp types.ConfigResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Name != tt.wantName {
+					t.Errorf("expected name %q, got %q", tt.wantName, resp.Name)
+				}
+				if resp.Cleanup == nil {
+					t.Fatal("expected non-nil Cleanup")
+				}
+				if resp.Cleanup.TTLSecondsAfterFinished == nil || *resp.Cleanup.TTLSecondsAfterFinished != 3600 {
+					t.Errorf("expected TTLSecondsAfterFinished=3600, got %v", resp.Cleanup.TTLSecondsAfterFinished)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigHandler_Update(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		body       string
+		wantStatus int
+	}{
+		{
+			name: "updates config spec",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.KubeOpenCodeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: kubeopenv1alpha1.KubeOpenCodeConfigSpec{},
+				},
+			},
+			body:       `{"spec":{"cleanup":{"ttlSecondsAfterFinished":7200}}}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "handles not found",
+			objects:    []runtime.Object{},
+			body:       `{"spec":{"cleanup":{"ttlSecondsAfterFinished":7200}}}`,
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "handles invalid YAML",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.KubeOpenCodeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: kubeopenv1alpha1.KubeOpenCodeConfigSpec{},
+				},
+			},
+			body:       `{not valid yaml or json`,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewConfigHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPut, "/api/v1/config", bytes.NewBufferString(tt.body))
+			r.URL = &url.URL{Path: "/api/v1/config"}
+
+			handler.Update(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var resp types.ConfigResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Name != "cluster" {
+					t.Errorf("expected name %q, got %q", "cluster", resp.Name)
+				}
+			}
+		})
+	}
+}
+
+// int32Ptr returns a pointer to an int32 value.
+func int32Ptr(v int32) *int32 {
+	return &v
+}

--- a/internal/server/handlers/crontask_handler_test.go
+++ b/internal/server/handlers/crontask_handler_test.go
@@ -1,0 +1,474 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
+	"github.com/kubeopencode/kubeopencode/internal/server/types"
+)
+
+func TestCronTaskHandler_ListAll(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		wantTotal  int
+		wantStatus int
+	}{
+		{
+			name: "returns crontasks across namespaces",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.CronTask{
+					ObjectMeta: metav1.ObjectMeta{Name: "ct-1", Namespace: "default"},
+					Spec: kubeopenv1alpha1.CronTaskSpec{
+						Schedule: "*/5 * * * *",
+						TaskTemplate: kubeopenv1alpha1.TaskTemplateSpec{
+							Spec: kubeopenv1alpha1.TaskSpec{
+								AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"},
+							},
+						},
+					},
+				},
+				&kubeopenv1alpha1.CronTask{
+					ObjectMeta: metav1.ObjectMeta{Name: "ct-2", Namespace: "production"},
+					Spec: kubeopenv1alpha1.CronTaskSpec{
+						Schedule: "0 * * * *",
+						TaskTemplate: kubeopenv1alpha1.TaskTemplateSpec{
+							Spec: kubeopenv1alpha1.TaskSpec{
+								AgentRef: &kubeopenv1alpha1.AgentReference{Name: "b"},
+							},
+						},
+					},
+				},
+			},
+			wantTotal:  2,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "returns empty list",
+			objects:    []runtime.Object{},
+			wantTotal:  0,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewCronTaskHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/crontasks", nil)
+			r.URL = &url.URL{Path: "/api/v1/crontasks"}
+
+			handler.ListAll(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			var resp types.CronTaskListResponse
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			if resp.Total != tt.wantTotal {
+				t.Errorf("expected total %d, got %d", tt.wantTotal, resp.Total)
+			}
+
+			if resp.Pagination == nil {
+				t.Fatal("expected non-nil pagination")
+			}
+		})
+	}
+}
+
+func TestCronTaskHandler_Get(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespace  string
+		ctName     string
+		objects    []runtime.Object
+		wantStatus int
+	}{
+		{
+			name:      "returns crontask",
+			namespace: "default",
+			ctName:    "my-ct",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.CronTask{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-ct", Namespace: "default"},
+					Spec: kubeopenv1alpha1.CronTaskSpec{
+						Schedule: "*/10 * * * *",
+						TaskTemplate: kubeopenv1alpha1.TaskTemplateSpec{
+							Spec: kubeopenv1alpha1.TaskSpec{
+								AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"},
+							},
+						},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "handles not found",
+			namespace:  "default",
+			ctName:     "missing",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewCronTaskHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", tt.namespace)
+			rctx.URLParams.Add("name", tt.ctName)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Get(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var resp types.CronTaskResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Name != tt.ctName {
+					t.Errorf("expected name %q, got %q", tt.ctName, resp.Name)
+				}
+				if resp.Schedule != "*/10 * * * *" {
+					t.Errorf("expected schedule %q, got %q", "*/10 * * * *", resp.Schedule)
+				}
+			}
+		})
+	}
+}
+
+func TestCronTaskHandler_Create(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       interface{}
+		wantStatus int
+	}{
+		{
+			name: "creates crontask with agentRef",
+			body: types.CreateCronTaskRequest{
+				Name:        "new-ct",
+				Schedule:    "*/5 * * * *",
+				Description: "run every 5 minutes",
+				AgentRef:    &types.AgentReference{Name: "my-agent"},
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "validates schedule required",
+			body: types.CreateCronTaskRequest{
+				Name:     "no-schedule",
+				AgentRef: &types.AgentReference{Name: "a"},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "validates agentRef or templateRef required",
+			body: types.CreateCronTaskRequest{
+				Name:     "no-ref",
+				Schedule: "*/5 * * * *",
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "validates mutual exclusivity of refs",
+			body: types.CreateCronTaskRequest{
+				Name:        "both-refs",
+				Schedule:    "*/5 * * * *",
+				AgentRef:    &types.AgentReference{Name: "a"},
+				TemplateRef: &types.AgentTemplateReference{Name: "t"},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "validates invalid cron expression",
+			body: types.CreateCronTaskRequest{
+				Name:     "bad-cron",
+				Schedule: "not a cron",
+				AgentRef: &types.AgentReference{Name: "a"},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+			handler := NewCronTaskHandler(k8sClient)
+
+			bodyBytes, _ := json.Marshal(tt.body)
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(bodyBytes))
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", "default")
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Create(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusCreated {
+				var resp types.CronTaskResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Namespace != "default" {
+					t.Errorf("expected namespace %q, got %q", "default", resp.Namespace)
+				}
+				if resp.Schedule != "*/5 * * * *" {
+					t.Errorf("expected schedule %q, got %q", "*/5 * * * *", resp.Schedule)
+				}
+			}
+		})
+	}
+}
+
+func TestCronTaskHandler_Suspend(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctName     string
+		objects    []runtime.Object
+		wantStatus int
+	}{
+		{
+			name:   "suspends crontask",
+			ctName: "my-ct",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.CronTask{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-ct", Namespace: "default"},
+					Spec: kubeopenv1alpha1.CronTaskSpec{
+						Schedule: "*/5 * * * *",
+						TaskTemplate: kubeopenv1alpha1.TaskTemplateSpec{
+							Spec: kubeopenv1alpha1.TaskSpec{
+								AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"},
+							},
+						},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "handles not found",
+			ctName:     "missing",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewCronTaskHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", nil)
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", "default")
+			rctx.URLParams.Add("name", tt.ctName)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Suspend(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				// Verify the crontask spec was updated
+				var ct kubeopenv1alpha1.CronTask
+				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: tt.ctName}, &ct); err != nil {
+					t.Fatalf("failed to get crontask: %v", err)
+				}
+				if ct.Spec.Suspend == nil || !*ct.Spec.Suspend {
+					t.Error("expected crontask.Spec.Suspend to be true")
+				}
+
+				var resp types.CronTaskResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if !resp.Suspend {
+					t.Error("expected response Suspend to be true")
+				}
+			}
+		})
+	}
+}
+
+func TestCronTaskHandler_Resume(t *testing.T) {
+	suspended := true
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(
+			&kubeopenv1alpha1.CronTask{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-ct", Namespace: "default"},
+				Spec: kubeopenv1alpha1.CronTaskSpec{
+					Schedule: "*/5 * * * *",
+					Suspend:  &suspended,
+					TaskTemplate: kubeopenv1alpha1.TaskTemplateSpec{
+						Spec: kubeopenv1alpha1.TaskSpec{
+							AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"},
+						},
+					},
+				},
+			},
+		).
+		Build()
+	handler := NewCronTaskHandler(k8sClient)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/", nil)
+	r.URL = &url.URL{Path: "/"}
+
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("namespace", "default")
+	rctx.URLParams.Add("name", "my-ct")
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+	handler.Resume(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, w.Code, w.Body.String())
+	}
+
+	// Verify the crontask spec was updated
+	var ct kubeopenv1alpha1.CronTask
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "my-ct"}, &ct); err != nil {
+		t.Fatalf("failed to get crontask: %v", err)
+	}
+	if ct.Spec.Suspend == nil || *ct.Spec.Suspend {
+		t.Error("expected crontask.Spec.Suspend to be false")
+	}
+
+	var resp types.CronTaskResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Suspend {
+		t.Error("expected response Suspend to be false")
+	}
+}
+
+func TestCronTaskHandler_Trigger(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctName     string
+		objects    []runtime.Object
+		wantStatus int
+	}{
+		{
+			name:   "triggers crontask",
+			ctName: "my-ct",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.CronTask{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-ct", Namespace: "default"},
+					Spec: kubeopenv1alpha1.CronTaskSpec{
+						Schedule: "*/5 * * * *",
+						TaskTemplate: kubeopenv1alpha1.TaskTemplateSpec{
+							Spec: kubeopenv1alpha1.TaskSpec{
+								AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"},
+							},
+						},
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "handles not found",
+			ctName:     "missing",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewCronTaskHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", nil)
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", "default")
+			rctx.URLParams.Add("name", tt.ctName)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Trigger(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				// Verify trigger annotation was set
+				var ct kubeopenv1alpha1.CronTask
+				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: tt.ctName}, &ct); err != nil {
+					t.Fatalf("failed to get crontask: %v", err)
+				}
+				if ct.Annotations[kubeopenv1alpha1.CronTaskTriggerAnnotation] != "true" {
+					t.Errorf("expected trigger annotation to be set, got annotations: %v", ct.Annotations)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/handlers/filter_test.go
+++ b/internal/server/handlers/filter_test.go
@@ -1,0 +1,219 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package handlers
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestParseFilterOptions(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		r := &http.Request{URL: &url.URL{RawQuery: ""}}
+		opts, err := ParseFilterOptions(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.Limit != 20 {
+			t.Errorf("default limit = %d, want 20", opts.Limit)
+		}
+		if opts.Offset != 0 {
+			t.Errorf("default offset = %d, want 0", opts.Offset)
+		}
+		if opts.SortOrder != "desc" {
+			t.Errorf("default sortOrder = %q, want desc", opts.SortOrder)
+		}
+		if opts.Name != "" {
+			t.Errorf("default name = %q, want empty", opts.Name)
+		}
+		if opts.Phase != "" {
+			t.Errorf("default phase = %q, want empty", opts.Phase)
+		}
+	})
+
+	t.Run("all params", func(t *testing.T) {
+		r := &http.Request{URL: &url.URL{
+			RawQuery: "name=foo&phase=Running&limit=50&offset=10&sortOrder=asc",
+		}}
+		opts, err := ParseFilterOptions(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.Name != "foo" {
+			t.Errorf("name = %q, want foo", opts.Name)
+		}
+		if opts.Phase != "Running" {
+			t.Errorf("phase = %q, want Running", opts.Phase)
+		}
+		if opts.Limit != 50 {
+			t.Errorf("limit = %d, want 50", opts.Limit)
+		}
+		if opts.Offset != 10 {
+			t.Errorf("offset = %d, want 10", opts.Offset)
+		}
+		if opts.SortOrder != "asc" {
+			t.Errorf("sortOrder = %q, want asc", opts.SortOrder)
+		}
+	})
+
+	t.Run("limit capped at 100", func(t *testing.T) {
+		r := &http.Request{URL: &url.URL{RawQuery: "limit=500"}}
+		opts, err := ParseFilterOptions(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.Limit != 100 {
+			t.Errorf("limit = %d, want 100 (capped)", opts.Limit)
+		}
+	})
+
+	t.Run("invalid limit uses default", func(t *testing.T) {
+		r := &http.Request{URL: &url.URL{RawQuery: "limit=abc"}}
+		opts, err := ParseFilterOptions(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.Limit != 20 {
+			t.Errorf("limit = %d, want 20 (default for invalid)", opts.Limit)
+		}
+	})
+
+	t.Run("negative limit uses default", func(t *testing.T) {
+		r := &http.Request{URL: &url.URL{RawQuery: "limit=-5"}}
+		opts, err := ParseFilterOptions(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.Limit != 20 {
+			t.Errorf("limit = %d, want 20 (default for negative)", opts.Limit)
+		}
+	})
+
+	t.Run("negative offset uses default", func(t *testing.T) {
+		r := &http.Request{URL: &url.URL{RawQuery: "offset=-1"}}
+		opts, err := ParseFilterOptions(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.Offset != 0 {
+			t.Errorf("offset = %d, want 0 (default for negative)", opts.Offset)
+		}
+	})
+
+	t.Run("invalid sortOrder uses default", func(t *testing.T) {
+		r := &http.Request{URL: &url.URL{RawQuery: "sortOrder=invalid"}}
+		opts, err := ParseFilterOptions(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.SortOrder != "desc" {
+			t.Errorf("sortOrder = %q, want desc (default for invalid)", opts.SortOrder)
+		}
+	})
+
+	t.Run("valid labelSelector", func(t *testing.T) {
+		r := &http.Request{URL: &url.URL{RawQuery: "labelSelector=app%3Dtest"}}
+		opts, err := ParseFilterOptions(r)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.LabelSelector == nil {
+			t.Fatal("expected non-nil LabelSelector")
+		}
+	})
+
+	t.Run("invalid labelSelector returns error", func(t *testing.T) {
+		r := &http.Request{URL: &url.URL{RawQuery: "labelSelector=%21%21invalid"}}
+		_, err := ParseFilterOptions(r)
+		if err == nil {
+			t.Fatal("expected error for invalid labelSelector")
+		}
+	})
+}
+
+func TestBuildListOptions(t *testing.T) {
+	t.Run("with namespace", func(t *testing.T) {
+		listOpts := BuildListOptions("my-ns", nil)
+		if len(listOpts) != 1 {
+			t.Errorf("expected 1 list option, got %d", len(listOpts))
+		}
+	})
+
+	t.Run("empty namespace", func(t *testing.T) {
+		listOpts := BuildListOptions("", nil)
+		if len(listOpts) != 0 {
+			t.Errorf("expected 0 list options for empty namespace, got %d", len(listOpts))
+		}
+	})
+
+	t.Run("with namespace and label selector", func(t *testing.T) {
+		r := &http.Request{URL: &url.URL{RawQuery: "labelSelector=app%3Dtest"}}
+		opts, _ := ParseFilterOptions(r)
+		listOpts := BuildListOptions("my-ns", opts)
+		if len(listOpts) != 2 {
+			t.Errorf("expected 2 list options (namespace + labels), got %d", len(listOpts))
+		}
+	})
+
+	t.Run("nil opts with namespace", func(t *testing.T) {
+		listOpts := BuildListOptions("ns", nil)
+		if len(listOpts) != 1 {
+			t.Errorf("expected 1 list option, got %d", len(listOpts))
+		}
+	})
+}
+
+func TestMatchesNameFilter(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter string
+		want   bool
+	}{
+		{"test-agent", "", true},      // empty filter matches all
+		{"test-agent", "test", true},  // substring match
+		{"test-agent", "AGENT", true}, // case insensitive
+		{"test-agent", "prod", false}, // no match
+		{"my-task-123", "task", true}, // middle substring
+		{"UPPERCASE", "upper", true},  // case insensitive both ways
+		{"", "anything", false},       // empty name
+		{"", "", true},                // both empty
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"_"+tt.filter, func(t *testing.T) {
+			got := MatchesNameFilter(tt.name, tt.filter)
+			if got != tt.want {
+				t.Errorf("MatchesNameFilter(%q, %q) = %v, want %v", tt.name, tt.filter, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesPhaseFilter(t *testing.T) {
+	tests := []struct {
+		phase  string
+		filter string
+		want   bool
+	}{
+		{"Running", "", true},                  // empty filter matches all
+		{"Running", "Running", true},           // exact match
+		{"running", "Running", true},           // case insensitive
+		{"Running", "running", true},           // case insensitive other way
+		{"Running", "Failed", false},           // no match
+		{"Running", "Running,Failed", true},    // comma-separated first
+		{"Failed", "Running,Failed", true},     // comma-separated second
+		{"Completed", "Running,Failed", false}, // comma-separated no match
+		{"Running", " Running ", true},         // trimmed whitespace
+		{"Failed", "Running, Failed", true},    // comma with space
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.phase+"_"+tt.filter, func(t *testing.T) {
+			got := MatchesPhaseFilter(tt.phase, tt.filter)
+			if got != tt.want {
+				t.Errorf("MatchesPhaseFilter(%q, %q) = %v, want %v", tt.phase, tt.filter, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/handlers/info_handler_test.go
+++ b/internal/server/handlers/info_handler_test.go
@@ -1,0 +1,123 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kubeopencode/kubeopencode/internal/server/types"
+)
+
+func TestInfoHandler_GetInfo(t *testing.T) {
+	scheme := newTestScheme()
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	handler := NewInfoHandler(k8sClient)
+
+	// Override Version for deterministic test
+	oldVersion := Version
+	Version = "v0.0.1-test"
+	defer func() { Version = oldVersion }()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/info", nil)
+	r.URL = &url.URL{Path: "/api/v1/info"}
+
+	handler.GetInfo(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var resp types.ServerInfo
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Version != "v0.0.1-test" {
+		t.Errorf("expected version %q, got %q", "v0.0.1-test", resp.Version)
+	}
+}
+
+func TestInfoHandler_ListNamespaces(t *testing.T) {
+	tests := []struct {
+		name       string
+		objects    []runtime.Object
+		wantCount  int
+		wantNames  []string
+		wantStatus int
+	}{
+		{
+			name: "returns namespaces sorted alphabetically",
+			objects: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "delta"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "alpha"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "charlie"}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "bravo"}},
+			},
+			wantCount:  4,
+			wantNames:  []string{"alpha", "bravo", "charlie", "delta"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "handles empty namespace list",
+			objects:    []runtime.Object{},
+			wantCount:  0,
+			wantNames:  []string{},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "single namespace",
+			objects: []runtime.Object{
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			},
+			wantCount:  1,
+			wantNames:  []string{"default"},
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewInfoHandler(k8sClient)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+			r.URL = &url.URL{Path: "/api/v1/namespaces"}
+
+			handler.ListNamespaces(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d", tt.wantStatus, w.Code)
+			}
+
+			var resp types.NamespaceList
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			if len(resp.Namespaces) != tt.wantCount {
+				t.Fatalf("expected %d namespaces, got %d", tt.wantCount, len(resp.Namespaces))
+			}
+
+			for i, want := range tt.wantNames {
+				if resp.Namespaces[i] != want {
+					t.Errorf("namespace[%d] = %q, want %q", i, resp.Namespaces[i], want)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/handlers/task_handler_test.go
+++ b/internal/server/handlers/task_handler_test.go
@@ -1,0 +1,455 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
+	"github.com/kubeopencode/kubeopencode/internal/server/types"
+)
+
+func TestTaskHandler_List(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespace  string
+		query      string
+		objects    []runtime.Object
+		wantTotal  int
+		wantStatus int
+	}{
+		{
+			name:      "returns tasks with pagination",
+			namespace: "default",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "task-1",
+						Namespace:         "default",
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+				},
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "task-2",
+						Namespace:         "default",
+						CreationTimestamp: metav1.Now(),
+					},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+				},
+			},
+			wantTotal:  2,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:      "filter by name",
+			namespace: "default",
+			query:     "name=task-1",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.TaskSpec{AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"}},
+				},
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "task-2", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.TaskSpec{AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"}},
+				},
+			},
+			wantTotal:  1,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:      "filter by phase",
+			namespace: "default",
+			query:     "phase=Running",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "task-running", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.TaskSpec{AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"}},
+					Status:     kubeopenv1alpha1.TaskExecutionStatus{Phase: kubeopenv1alpha1.TaskPhaseRunning},
+				},
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "task-completed", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.TaskSpec{AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"}},
+					Status:     kubeopenv1alpha1.TaskExecutionStatus{Phase: kubeopenv1alpha1.TaskPhaseCompleted},
+				},
+			},
+			wantTotal:  1,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "empty list",
+			namespace:  "default",
+			objects:    []runtime.Object{},
+			wantTotal:  0,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewTaskHandler(k8sClient, nil, nil)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/"+tt.namespace+"/tasks", nil)
+			r.URL = &url.URL{Path: "/api/v1/namespaces/" + tt.namespace + "/tasks", RawQuery: tt.query}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", tt.namespace)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.List(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			var resp types.TaskListResponse
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+
+			if resp.Total != tt.wantTotal {
+				t.Errorf("expected total %d, got %d", tt.wantTotal, resp.Total)
+			}
+		})
+	}
+}
+
+func TestTaskHandler_Get(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespace  string
+		taskName   string
+		objects    []runtime.Object
+		wantStatus int
+	}{
+		{
+			name:      "returns task",
+			namespace: "default",
+			taskName:  "my-task",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-task", Namespace: "default"},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef:    &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+						Description: strPtr("do something"),
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "handles not found",
+			namespace:  "default",
+			taskName:   "missing",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewTaskHandler(k8sClient, nil, nil)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", tt.namespace)
+			rctx.URLParams.Add("name", tt.taskName)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Get(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusOK {
+				var resp types.TaskResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Name != tt.taskName {
+					t.Errorf("expected name %q, got %q", tt.taskName, resp.Name)
+				}
+				if resp.Description != "do something" {
+					t.Errorf("expected description %q, got %q", "do something", resp.Description)
+				}
+			}
+		})
+	}
+}
+
+func TestTaskHandler_Create(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       interface{}
+		wantStatus int
+		wantErr    string
+	}{
+		{
+			name: "creates task with agentRef",
+			body: types.CreateTaskRequest{
+				Name:        "new-task",
+				Description: "test task",
+				AgentRef:    &types.AgentReference{Name: "my-agent"},
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "creates task with templateRef",
+			body: types.CreateTaskRequest{
+				Name:        "tmpl-task",
+				Description: "template task",
+				TemplateRef: &types.AgentTemplateReference{Name: "my-tmpl"},
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "validates description required",
+			body: types.CreateTaskRequest{
+				Name:     "no-desc",
+				AgentRef: &types.AgentReference{Name: "my-agent"},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "validates mutual exclusivity",
+			body: types.CreateTaskRequest{
+				Name:        "both-refs",
+				Description: "has both",
+				AgentRef:    &types.AgentReference{Name: "a"},
+				TemplateRef: &types.AgentTemplateReference{Name: "t"},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "validates at least one ref required",
+			body: types.CreateTaskRequest{
+				Name:        "no-refs",
+				Description: "no refs",
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+			handler := NewTaskHandler(k8sClient, nil, nil)
+
+			bodyBytes, _ := json.Marshal(tt.body)
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(bodyBytes))
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", "default")
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Create(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			if tt.wantStatus == http.StatusCreated {
+				var resp types.TaskResponse
+				if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if resp.Namespace != "default" {
+					t.Errorf("expected namespace %q, got %q", "default", resp.Namespace)
+				}
+			}
+		})
+	}
+}
+
+func TestTaskHandler_Delete(t *testing.T) {
+	tests := []struct {
+		name       string
+		taskName   string
+		objects    []runtime.Object
+		wantStatus int
+	}{
+		{
+			name:     "deletes task",
+			taskName: "my-task",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-task", Namespace: "default"},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"},
+					},
+				},
+			},
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "handles not found",
+			taskName:   "missing",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				Build()
+			handler := NewTaskHandler(k8sClient, nil, nil)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodDelete, "/", nil)
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", "default")
+			rctx.URLParams.Add("name", tt.taskName)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Delete(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			// Verify deletion
+			if tt.wantStatus == http.StatusNoContent {
+				var task kubeopenv1alpha1.Task
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: tt.taskName}, &task)
+				if err == nil {
+					t.Error("expected task to be deleted")
+				}
+			}
+		})
+	}
+}
+
+func TestTaskHandler_Stop(t *testing.T) {
+	tests := []struct {
+		name       string
+		taskName   string
+		objects    []runtime.Object
+		wantStatus int
+	}{
+		{
+			name:     "stops running task",
+			taskName: "running-task",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "running-task", Namespace: "default"},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"},
+					},
+					Status: kubeopenv1alpha1.TaskExecutionStatus{
+						Phase: kubeopenv1alpha1.TaskPhaseRunning,
+					},
+				},
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:     "rejects non-running task",
+			taskName: "completed-task",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "completed-task", Namespace: "default"},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "a"},
+					},
+					Status: kubeopenv1alpha1.TaskExecutionStatus{
+						Phase: kubeopenv1alpha1.TaskPhaseCompleted,
+					},
+				},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "handles not found",
+			taskName:   "missing",
+			objects:    []runtime.Object{},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				WithStatusSubresource(&kubeopenv1alpha1.Task{}).
+				Build()
+			handler := NewTaskHandler(k8sClient, nil, nil)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodPost, "/", nil)
+			r.URL = &url.URL{Path: "/"}
+
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("namespace", "default")
+			rctx.URLParams.Add("name", tt.taskName)
+			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+
+			handler.Stop(w, r)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantStatus, w.Code, w.Body.String())
+			}
+
+			// Verify annotation was added
+			if tt.wantStatus == http.StatusOK {
+				var task kubeopenv1alpha1.Task
+				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: tt.taskName}, &task); err != nil {
+					t.Fatalf("failed to get task: %v", err)
+				}
+				if task.Annotations["kubeopencode.io/stop"] != "true" {
+					t.Errorf("expected stop annotation to be set, got annotations: %v", task.Annotations)
+				}
+			}
+		})
+	}
+}
+
+// strPtr returns a pointer to a string value.
+func strPtr(s string) *string {
+	return &s
+}

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -284,6 +284,61 @@ export const handlers = [
     return HttpResponse.json(newAgent, { status: 201 });
   }),
 
+  http.delete(`${API_BASE}/namespaces/:namespace/agents/:name`, ({ params }) => {
+    const { namespace, name } = params;
+    const agent = mockAgents.find((a) => a.namespace === namespace && a.name === name);
+    if (!agent) {
+      return HttpResponse.json({ error: 'agent not found' }, { status: 404 });
+    }
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.put(`${API_BASE}/namespaces/:namespace/agents/:name`, async ({ params, request }) => {
+    const { namespace, name } = params;
+    const agent = mockAgents.find((a) => a.namespace === namespace && a.name === name);
+    if (!agent) {
+      return HttpResponse.json({ error: 'agent not found' }, { status: 404 });
+    }
+    const body = await request.text();
+    return new HttpResponse(body, { headers: { 'Content-Type': 'text/plain' } });
+  }),
+
+  http.get(`${API_BASE}/namespaces/:namespace/agents/:name/share`, ({ params }) => {
+    const { namespace, name } = params;
+    const agent = mockAgents.find((a) => a.namespace === namespace && a.name === name);
+    if (!agent) {
+      return HttpResponse.json({ error: 'agent not found' }, { status: 404 });
+    }
+    return HttpResponse.json({
+      enabled: agent.share?.enabled || false,
+      url: agent.share?.url || '',
+      active: agent.share?.active || false,
+    });
+  }),
+
+  http.post(`${API_BASE}/namespaces/:namespace/agents/:name/share`, async ({ params, request }) => {
+    const { namespace, name } = params;
+    const agent = mockAgents.find((a) => a.namespace === namespace && a.name === name);
+    if (!agent) {
+      return HttpResponse.json({ error: 'agent not found' }, { status: 404 });
+    }
+    const body = await request.json() as Record<string, unknown>;
+    return HttpResponse.json({
+      enabled: body.enabled ?? true,
+      url: `http://localhost:2746/s/mock-token-${name}`,
+      active: true,
+    });
+  }),
+
+  http.delete(`${API_BASE}/namespaces/:namespace/agents/:name/share`, ({ params }) => {
+    const { namespace, name } = params;
+    const agent = mockAgents.find((a) => a.namespace === namespace && a.name === name);
+    if (!agent) {
+      return HttpResponse.json({ error: 'agent not found' }, { status: 404 });
+    }
+    return HttpResponse.json({ enabled: false, url: '', active: false });
+  }),
+
   http.post(`${API_BASE}/namespaces/:namespace/agents/:name/suspend`, ({ params }) => {
     const { namespace, name } = params;
     const agent = mockAgents.find((a) => a.namespace === namespace && a.name === name);
@@ -454,6 +509,25 @@ export const handlers = [
       createdAt: new Date().toISOString(),
     };
     return HttpResponse.json(newTemplate, { status: 201 });
+  }),
+
+  http.delete(`${API_BASE}/namespaces/:namespace/agenttemplates/:name`, ({ params }) => {
+    const { namespace, name } = params;
+    const template = mockAgentTemplates.find((t) => t.namespace === namespace && t.name === name);
+    if (!template) {
+      return HttpResponse.json({ error: 'agent template not found' }, { status: 404 });
+    }
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.put(`${API_BASE}/namespaces/:namespace/agenttemplates/:name`, async ({ params, request }) => {
+    const { namespace, name } = params;
+    const template = mockAgentTemplates.find((t) => t.namespace === namespace && t.name === name);
+    if (!template) {
+      return HttpResponse.json({ error: 'agent template not found' }, { status: 404 });
+    }
+    const body = await request.text();
+    return new HttpResponse(body, { headers: { 'Content-Type': 'text/plain' } });
   }),
 
   http.get(`${API_BASE}/namespaces/:namespace/agenttemplates/:name`, ({ params, request }) => {

--- a/ui/src/pages/__tests__/AgentCreatePage.test.tsx
+++ b/ui/src/pages/__tests__/AgentCreatePage.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import AgentCreatePage from '../AgentCreatePage';
+
+// Mock TimeAgo to avoid timing issues
+vi.mock('../../components/TimeAgo', () => ({
+  default: ({ date }: { date: string }) => <span>{date}</span>,
+}));
+
+describe('AgentCreatePage', () => {
+  beforeEach(() => {
+    // Clear cookies
+    document.cookie.split(';').forEach((c) => {
+      document.cookie = c.trim().split('=')[0] + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
+    });
+  });
+
+  it('renders page title', () => {
+    renderWithProviders(<AgentCreatePage />, { initialEntries: ['/agents/create'] });
+
+    expect(screen.getByRole('heading', { name: 'Create Agent' })).toBeInTheDocument();
+  });
+
+  it('renders form fields', () => {
+    renderWithProviders(<AgentCreatePage />, { initialEntries: ['/agents/create'] });
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+  });
+
+  it('renders cancel and submit buttons', () => {
+    renderWithProviders(<AgentCreatePage />, { initialEntries: ['/agents/create'] });
+
+    const cancelLink = screen.getByText('Cancel');
+    expect(cancelLink.closest('a')).toHaveAttribute('href', '/agents');
+
+    const submitButton = screen.getByRole('button', { name: 'Create Agent' });
+    expect(submitButton).toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/__tests__/AgentTemplateCreatePage.test.tsx
+++ b/ui/src/pages/__tests__/AgentTemplateCreatePage.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import AgentTemplateCreatePage from '../AgentTemplateCreatePage';
+
+// Mock TimeAgo to avoid timing issues
+vi.mock('../../components/TimeAgo', () => ({
+  default: ({ date }: { date: string }) => <span>{date}</span>,
+}));
+
+describe('AgentTemplateCreatePage', () => {
+  beforeEach(() => {
+    // Clear cookies
+    document.cookie.split(';').forEach((c) => {
+      document.cookie = c.trim().split('=')[0] + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
+    });
+  });
+
+  it('renders page title', () => {
+    renderWithProviders(<AgentTemplateCreatePage />, { initialEntries: ['/templates/create'] });
+
+    expect(screen.getByRole('heading', { name: 'Create Agent Template' })).toBeInTheDocument();
+  });
+
+  it('renders form fields', () => {
+    renderWithProviders(<AgentTemplateCreatePage />, { initialEntries: ['/templates/create'] });
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText(/Workspace Directory/)).toBeInTheDocument();
+  });
+
+  it('renders cancel and submit buttons', () => {
+    renderWithProviders(<AgentTemplateCreatePage />, { initialEntries: ['/templates/create'] });
+
+    const cancelLink = screen.getByText('Cancel');
+    expect(cancelLink.closest('a')).toHaveAttribute('href', '/templates');
+
+    const submitButton = screen.getByRole('button', { name: 'Create Template' });
+    expect(submitButton).toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/__tests__/AgentTemplateDetailPage.test.tsx
+++ b/ui/src/pages/__tests__/AgentTemplateDetailPage.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { renderWithProviders } from '../../test/utils';
+import AgentTemplateDetailPage from '../AgentTemplateDetailPage';
+import { Route, Routes } from 'react-router-dom';
+
+// Mock TimeAgo to avoid timing issues
+vi.mock('../../components/TimeAgo', () => ({
+  default: ({ date }: { date: string }) => <span>{date}</span>,
+}));
+
+// Mock YamlViewer to simplify tests
+vi.mock('../../components/YamlViewer', () => ({
+  default: () => <div data-testid="yaml-viewer">YamlViewer</div>,
+}));
+
+function renderAgentTemplateDetailPage(namespace: string, name: string) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/templates/:namespace/:name" element={<AgentTemplateDetailPage />} />
+    </Routes>,
+    { initialEntries: [`/templates/${namespace}/${name}`] }
+  );
+}
+
+describe('AgentTemplateDetailPage', () => {
+  it('renders template name', async () => {
+    renderAgentTemplateDetailPage('default', 'standard-base');
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'standard-base' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows not found error', async () => {
+    renderAgentTemplateDetailPage('default', 'nonexistent-template');
+
+    await waitFor(() => {
+      expect(screen.getByText(/not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders delete button', async () => {
+    renderAgentTemplateDetailPage('default', 'standard-base');
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete')).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/pages/__tests__/AgentTemplatesPage.test.tsx
+++ b/ui/src/pages/__tests__/AgentTemplatesPage.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { renderWithProviders } from '../../test/utils';
+import AgentTemplatesPage from '../AgentTemplatesPage';
+
+// Mock TimeAgo to avoid timing issues
+vi.mock('../../components/TimeAgo', () => ({
+  default: ({ date }: { date: string }) => <span>{date}</span>,
+}));
+
+describe('AgentTemplatesPage', () => {
+  beforeEach(() => {
+    // Clear cookies
+    document.cookie.split(';').forEach((c) => {
+      document.cookie = c.trim().split('=')[0] + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
+    });
+  });
+
+  it('renders page title', async () => {
+    renderWithProviders(<AgentTemplatesPage />, { initialEntries: ['/templates'] });
+
+    expect(screen.getByText('Agent Templates')).toBeInTheDocument();
+    expect(screen.getByText('Reusable base configurations for creating Agents')).toBeInTheDocument();
+  });
+
+  it('renders template cards from API', async () => {
+    renderWithProviders(<AgentTemplatesPage />, { initialEntries: ['/templates'] });
+
+    await waitFor(() => {
+      expect(screen.getByText('standard-base')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('local-dev-base')).toBeInTheDocument();
+    expect(screen.getByText('production-base')).toBeInTheDocument();
+  });
+
+  it('shows error state when API fails', async () => {
+    server.use(
+      http.get('/api/v1/agenttemplates', () => {
+        return HttpResponse.json({ message: 'Server error' }, { status: 500 });
+      })
+    );
+
+    renderWithProviders(<AgentTemplatesPage />, { initialEntries: ['/templates'] });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Error loading templates/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Retry')).toBeInTheDocument();
+  });
+
+  it('shows empty state', async () => {
+    server.use(
+      http.get('/api/v1/agenttemplates', () => {
+        return HttpResponse.json({
+          templates: [],
+          total: 0,
+          pagination: { limit: 12, offset: 0, totalCount: 0, hasMore: false },
+        });
+      })
+    );
+
+    renderWithProviders(<AgentTemplatesPage />, { initialEntries: ['/templates'] });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No agent templates found/)).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/pages/__tests__/ConfigPage.test.tsx
+++ b/ui/src/pages/__tests__/ConfigPage.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { renderWithProviders } from '../../test/utils';
+import ConfigPage from '../ConfigPage';
+
+// Mock YamlViewer to avoid complex rendering
+vi.mock('../../components/YamlViewer', () => ({
+  default: () => <div data-testid="yaml-viewer">YamlViewer</div>,
+}));
+
+describe('ConfigPage', () => {
+  beforeEach(() => {
+    // Clear cookies
+    document.cookie.split(';').forEach((c) => {
+      document.cookie = c.trim().split('=')[0] + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
+    });
+  });
+
+  it('renders page title', async () => {
+    renderWithProviders(<ConfigPage />, { initialEntries: ['/config'] });
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Cluster Configuration' })).toBeInTheDocument();
+    });
+  });
+
+  it('renders config sections', async () => {
+    renderWithProviders(<ConfigPage />, { initialEntries: ['/config'] });
+
+    await waitFor(() => {
+      expect(screen.getByText('System Image')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Task Cleanup')).toBeInTheDocument();
+    expect(screen.getByText('Proxy')).toBeInTheDocument();
+  });
+
+  it('shows not found state when config does not exist', async () => {
+    server.use(
+      http.get('/api/v1/config', () => {
+        return HttpResponse.json({ error: 'not found' }, { status: 404 });
+      })
+    );
+
+    renderWithProviders(<ConfigPage />, { initialEntries: ['/config'] });
+
+    await waitFor(() => {
+      expect(screen.getByText('No Configuration Found')).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/pages/__tests__/CronTaskCreatePage.test.tsx
+++ b/ui/src/pages/__tests__/CronTaskCreatePage.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import CronTaskCreatePage from '../CronTaskCreatePage';
+
+// Mock TimeAgo to avoid timing issues
+vi.mock('../../components/TimeAgo', () => ({
+  default: ({ date }: { date: string }) => <span>{date}</span>,
+}));
+
+describe('CronTaskCreatePage', () => {
+  beforeEach(() => {
+    // Clear cookies
+    document.cookie.split(';').forEach((c) => {
+      document.cookie = c.trim().split('=')[0] + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
+    });
+  });
+
+  it('renders page title and breadcrumbs', () => {
+    renderWithProviders(<CronTaskCreatePage />, { initialEntries: ['/crontasks/create'] });
+
+    expect(screen.getByRole('heading', { name: 'Create CronTask' })).toBeInTheDocument();
+    const breadcrumb = screen.getByLabelText('Breadcrumb');
+    expect(breadcrumb.textContent).toContain('CronTasks');
+  });
+
+  it('renders form fields', () => {
+    renderWithProviders(<CronTaskCreatePage />, { initialEntries: ['/crontasks/create'] });
+
+    expect(screen.getByText('Schedule')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+  });
+
+  it('renders cancel and submit buttons', () => {
+    renderWithProviders(<CronTaskCreatePage />, { initialEntries: ['/crontasks/create'] });
+
+    const cancelLink = screen.getByText('Cancel');
+    expect(cancelLink.closest('a')).toHaveAttribute('href', '/crontasks');
+
+    const submitButton = screen.getByRole('button', { name: 'Create CronTask' });
+    expect(submitButton).toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/__tests__/CronTaskDetailPage.test.tsx
+++ b/ui/src/pages/__tests__/CronTaskDetailPage.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { renderWithProviders } from '../../test/utils';
+import CronTaskDetailPage from '../CronTaskDetailPage';
+import { Route, Routes } from 'react-router-dom';
+
+// Mock TimeAgo to avoid timing issues
+vi.mock('../../components/TimeAgo', () => ({
+  default: ({ date }: { date: string }) => <span>{date}</span>,
+}));
+
+// Mock YamlViewer to simplify tests
+vi.mock('../../components/YamlViewer', () => ({
+  default: () => <div data-testid="yaml-viewer">YamlViewer</div>,
+}));
+
+function renderCronTaskDetailPage(namespace: string, name: string) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/crontasks/:namespace/:name" element={<CronTaskDetailPage />} />
+    </Routes>,
+    { initialEntries: [`/crontasks/${namespace}/${name}`] }
+  );
+}
+
+describe('CronTaskDetailPage', () => {
+  it('renders crontask name and status', async () => {
+    renderCronTaskDetailPage('default', 'daily-vuln-scan');
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'daily-vuln-scan' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+  });
+
+  it('renders schedule information', async () => {
+    renderCronTaskDetailPage('default', 'daily-vuln-scan');
+
+    await waitFor(() => {
+      expect(screen.getByText('0 9 * * 1-5')).toBeInTheDocument();
+    });
+  });
+
+  it('shows not found error for invalid crontask', async () => {
+    renderCronTaskDetailPage('default', 'nonexistent-crontask');
+
+    await waitFor(() => {
+      expect(screen.getByText(/not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders action buttons', async () => {
+    renderCronTaskDetailPage('default', 'daily-vuln-scan');
+
+    await waitFor(() => {
+      expect(screen.getByText('Run Now')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Suspend')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/__tests__/CronTasksPage.test.tsx
+++ b/ui/src/pages/__tests__/CronTasksPage.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { renderWithProviders } from '../../test/utils';
+import CronTasksPage from '../CronTasksPage';
+
+// Mock TimeAgo to avoid timing issues
+vi.mock('../../components/TimeAgo', () => ({
+  default: ({ date }: { date: string }) => <span>{date}</span>,
+}));
+
+describe('CronTasksPage', () => {
+  beforeEach(() => {
+    // Clear cookies
+    document.cookie.split(';').forEach((c) => {
+      document.cookie = c.trim().split('=')[0] + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/';
+    });
+  });
+
+  it('renders page title and description', async () => {
+    renderWithProviders(<CronTasksPage />, { initialEntries: ['/crontasks'] });
+
+    expect(screen.getByText('CronTasks')).toBeInTheDocument();
+    expect(screen.getByText('Scheduled AI agent tasks running on a cron schedule')).toBeInTheDocument();
+  });
+
+  it('renders crontask list from API', async () => {
+    renderWithProviders(<CronTasksPage />, { initialEntries: ['/crontasks'] });
+
+    await waitFor(() => {
+      expect(screen.getByText('daily-vuln-scan')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('weekly-code-review')).toBeInTheDocument();
+  });
+
+  it('shows error state when API fails', async () => {
+    server.use(
+      http.get('/api/v1/crontasks', () => {
+        return HttpResponse.json({ message: 'Server error' }, { status: 500 });
+      })
+    );
+
+    renderWithProviders(<CronTasksPage />, { initialEntries: ['/crontasks'] });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Error loading CronTasks/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Retry')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no crontasks exist', async () => {
+    server.use(
+      http.get('/api/v1/crontasks', () => {
+        return HttpResponse.json({
+          cronTasks: [],
+          total: 0,
+          pagination: { limit: 20, offset: 0, totalCount: 0, hasMore: false },
+        });
+      })
+    );
+
+    renderWithProviders(<CronTasksPage />, { initialEntries: ['/crontasks'] });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No CronTasks found/)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add unit tests for previously uncovered core logic: context processor, plugin-init containers, TUI plugin handling, git workspace root merge, recurseSubmodules, applySystemDefaults, CronTask scheduling edge cases, and server filter utilities
- Add server handler tests for all 6 handler files (task, agent, agenttemplate, crontask, config, info) using httptest + fake K8s client
- Add integration tests for CronTask Replace and Allow concurrency policies
- Add UI page tests for 8 previously untested pages: CronTask (list/detail/create), AgentTemplate (list/detail/create), AgentCreate, Config
- Add 7 missing MSW mock handlers for agent delete/update/share and template delete/update

## Coverage Improvements

| Category | Before | After |
|----------|--------|-------|
| UI pages with tests | 6/16 (37%) | 14/16 (87%) |
| Server handler files with tests | 2/10 (20%) | 8/10 (80%) |
| Mock handler coverage | 31/38 (82%) | 38/38 (100%) |

## New Files (13)

**Go unit tests:**
- `internal/controller/context_processor_test.go` — 15 tests
- `internal/controller/crontask_unit_test.go` — 11 tests
- `internal/server/handlers/filter_test.go` — 20 tests
- `internal/server/handlers/{info,config,task,agent,agenttemplate,crontask}_handler_test.go` — 59 tests total

**UI tests:**
- `ui/src/pages/__tests__/{CronTasksPage,CronTaskDetailPage,CronTaskCreatePage,AgentTemplatesPage,AgentTemplateDetailPage,AgentTemplateCreatePage,AgentCreatePage,ConfigPage}.test.tsx` — 27 tests total

## Modified Files (5)

- `internal/controller/pod_builder_test.go` — +11 tests (plugins, TUI, workspace root, recurseSubmodules, applySystemDefaults)
- `internal/controller/server_builder_test.go` — +6 tests (plugins, TUI, workspace root)
- `internal/controller/crontask_controller_test.go` — +2 integration tests (Replace, Allow concurrency)
- `ui/src/mocks/handlers.ts` — +7 missing mock handlers

## Verification

- `make test` — all unit tests pass
- `make integration-test` — 82/83 pass (1 Pending = known URL context TODO)
- UI tests (`npx vitest run`) — 223/223 pass, 27 files
- `make lint` — 0 issues