### PR TITLE
chore: release v0.0.27

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.0.26
+- **Version**: v0.0.27
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.26
+VERSION ?= 0.0.27
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.4.3
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.26
+VERSION ?= 0.0.27
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.26
-appVersion: "v0.0.26"
+version: 0.0.27
+appVersion: "v0.0.27"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

- Update VERSION to 0.0.27 in Makefile and agents/Makefile
- Update Chart.yaml version to 0.0.27 and appVersion to v0.0.27
- Update AGENTS.md project status version

## Changes since v0.0.26

- **feat**: Add extraVolumes and extraVolumeMounts to AgentPodSpec (#162)
- **feat**: Improve CLI usability and add Agent event recording (#162)
- **test**: Add comprehensive test coverage across all tiers (#163)
- **docs**: Clarify two approaches for using skills (file-based and CRD)
- **chore(deps)**: Bump pnpm/action-setup, actions/upload-pages-artifact, go-dependencies, moby/spdystream

## CRD Changes

This release includes CRD changes (`extraVolumes`, `extraVolumeMounts` fields in AgentPodSpec). Users upgrading must manually apply CRD updates.