### PR TITLE
chore: release v0.0.28

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.0.27
+- **Version**: v0.0.28
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.27
+VERSION ?= 0.0.28
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.14.19
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.27
+VERSION ?= 0.0.28
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.27
-appVersion: "v0.0.27"
+version: 0.0.28
+appVersion: "v0.0.28"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

Prepare release v0.0.28.

### Changes since v0.0.27

- **feat**: Expose OpenCode sessions in Task status and add session proxy API
- **fix**: Remove internal cluster URL from SessionInfo
- **fix(controller)**: Add name tiebreaker to retention cleanup sort (#168)
- **refactor(crontask)**: Remove redundant cron.NewParser call (#167)
- **chore**: Upgrade opencode agent version from 1.4.3 to 1.14.19

### Version bumps in this PR

- `Makefile` VERSION: 0.0.27 → 0.0.28
- `agents/Makefile` VERSION: 0.0.27 → 0.0.28
- `charts/kubeopencode/Chart.yaml` version: 0.0.28, appVersion: v0.0.28
- `AGENTS.md` project status version

### CRD Changes

This release includes CRD changes (new session fields in Task status). Users upgrading will need to manually update CRDs.