### PR TITLE
fix: resolve correct session when Task is recreated with same name

### DIFF
--- a/docs/adr/0035-task-session-integration.md
+++ b/docs/adr/0035-task-session-integration.md
@@ -116,7 +116,11 @@ This adds Pod complexity but cleanly separates concerns.
 
 This is the most elegant but adds a dependency on the plugin system.
 
-**Recommended: Option B (Controller polls Agent API)** for initial implementation due to simplicity. The controller already knows the Agent's server URL and can query sessions. Title-based matching can be made reliable by using a deterministic title format (e.g., `"kubeopencode/<namespace>/<task-name>"`) and adding a `--title` flag that is always set.
+**Recommended: Option B (Controller polls Agent API)** for initial implementation due to simplicity. The controller already knows the Agent's server URL and can query sessions. Title-based matching is made reliable by using a unique title format that includes the Task UID prefix (e.g., `"kubeopencode/<namespace>/<task-name>/<uid-prefix>"`) and adding a `--title` flag that is always set.
+
+> **Note (2026-04-26):** The original implementation used `"kubeopencode/<namespace>/<task-name>"` as the session title, which caused incorrect session matching when a Task was deleted and recreated with the same name (multiple sessions shared the same title). This was fixed by:
+> 1. Appending the first 8 characters of `task.metadata.uid` to the session title, making it unique per Task object.
+> 2. Changing `FindSessionByTitle` to return the most recently created session (by `Time.Created`) when multiple sessions match, as a defense-in-depth measure.
 
 ### Phase 2: Session Proxy API in KubeOpenCode Server
 

--- a/internal/controller/opencode_client.go
+++ b/internal/controller/opencode_client.go
@@ -94,14 +94,19 @@ func (c *OpenCodeClient) FindSessionByTitle(ctx context.Context, serverURL, titl
 		return nil, fmt.Errorf("decoding response: %w", err)
 	}
 
-	// Find exact title match
+	// Find exact title match. When multiple sessions share the same title
+	// (e.g., Task deleted and recreated with the same name), return the
+	// most recently created session.
+	var latest *OpenCodeSession
 	for i := range sessions {
 		if sessions[i].Title == title {
-			return &sessions[i], nil
+			if latest == nil || sessions[i].Time.Created > latest.Time.Created {
+				latest = &sessions[i]
+			}
 		}
 	}
 
-	return nil, nil
+	return latest, nil
 }
 
 // GetSession retrieves a session by ID from the OpenCode server.

--- a/internal/controller/opencode_client_test.go
+++ b/internal/controller/opencode_client_test.go
@@ -1,0 +1,136 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newSession creates an OpenCodeSession for testing.
+func newSession(id, title string, created int64) OpenCodeSession {
+	s := OpenCodeSession{
+		ID:    id,
+		Title: title,
+	}
+	s.Time.Created = created
+	s.Time.Updated = created
+	return s
+}
+
+func TestFindSessionByTitle_ReturnsLatestWhenMultipleMatch(t *testing.T) {
+	sessions := []OpenCodeSession{
+		newSession("ses_old", "kubeopencode/default/my-task", 1000),
+		newSession("ses_new", "kubeopencode/default/my-task", 2000),
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sessions)
+	}))
+	defer srv.Close()
+
+	client := NewOpenCodeClient()
+	session, err := client.FindSessionByTitle(context.Background(), srv.URL, "kubeopencode/default/my-task")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if session == nil {
+		t.Fatal("expected session, got nil")
+	}
+	if session.ID != "ses_new" {
+		t.Errorf("expected latest session ses_new, got %s", session.ID)
+	}
+}
+
+func TestFindSessionByTitle_ReturnsLatestRegardlessOfOrder(t *testing.T) {
+	// Sessions returned in arbitrary order — should still pick latest by Created time.
+	sessions := []OpenCodeSession{
+		newSession("ses_newest", "kubeopencode/default/task", 3000),
+		newSession("ses_oldest", "kubeopencode/default/task", 1000),
+		newSession("ses_middle", "kubeopencode/default/task", 2000),
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sessions)
+	}))
+	defer srv.Close()
+
+	client := NewOpenCodeClient()
+	session, err := client.FindSessionByTitle(context.Background(), srv.URL, "kubeopencode/default/task")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if session == nil {
+		t.Fatal("expected session, got nil")
+	}
+	if session.ID != "ses_newest" {
+		t.Errorf("expected latest session ses_newest, got %s", session.ID)
+	}
+}
+
+func TestFindSessionByTitle_NoMatch(t *testing.T) {
+	sessions := []OpenCodeSession{
+		newSession("ses_1", "kubeopencode/default/other-task", 1000),
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sessions)
+	}))
+	defer srv.Close()
+
+	client := NewOpenCodeClient()
+	session, err := client.FindSessionByTitle(context.Background(), srv.URL, "kubeopencode/default/my-task")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if session != nil {
+		t.Errorf("expected nil session for non-matching title, got %+v", session)
+	}
+}
+
+func TestFindSessionByTitle_SingleMatch(t *testing.T) {
+	sessions := []OpenCodeSession{
+		newSession("ses_only", "kubeopencode/default/my-task/abcdef12", 1000),
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sessions)
+	}))
+	defer srv.Close()
+
+	client := NewOpenCodeClient()
+	session, err := client.FindSessionByTitle(context.Background(), srv.URL, "kubeopencode/default/my-task/abcdef12")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if session == nil {
+		t.Fatal("expected session, got nil")
+	}
+	if session.ID != "ses_only" {
+		t.Errorf("expected ses_only, got %s", session.ID)
+	}
+}
+
+func TestFindSessionByTitle_EmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]OpenCodeSession{})
+	}))
+	defer srv.Close()
+
+	client := NewOpenCodeClient()
+	session, err := client.FindSessionByTitle(context.Background(), srv.URL, "kubeopencode/default/my-task")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if session != nil {
+		t.Errorf("expected nil session for empty response, got %+v", session)
+	}
+}

--- a/internal/controller/pod_builder.go
+++ b/internal/controller/pod_builder.go
@@ -1402,12 +1402,18 @@ func configHasPermission(config *runtime.RawExtension) bool {
 	return ok
 }
 
-// sessionTitle generates a deterministic session title for the OpenCode session.
-// Format: "kubeopencode/<namespace>/<task-name>"
-// This deterministic format enables the Task controller to look up the session
-// by title via the OpenCode API (GET /session?search=<title>).
+// sessionTitle generates a unique session title for the OpenCode session.
+// Format: "kubeopencode/<namespace>/<task-name>/<uid-prefix>"
+// The UID prefix ensures uniqueness when a Task is deleted and recreated with
+// the same name (each new Task object gets a new UID from Kubernetes).
+// This enables the Task controller to look up the correct session by title
+// via the OpenCode API (GET /session?search=<title>).
 func sessionTitle(task *kubeopenv1alpha1.Task) string {
-	return fmt.Sprintf("kubeopencode/%s/%s", task.Namespace, task.Name)
+	uid := string(task.UID)
+	if len(uid) > 8 {
+		uid = uid[:8]
+	}
+	return fmt.Sprintf("kubeopencode/%s/%s/%s", task.Namespace, task.Name, uid)
 }
 
 // shellEscape wraps a string in single quotes for safe use in shell commands.

--- a/internal/controller/pod_builder_test.go
+++ b/internal/controller/pod_builder_test.go
@@ -1969,9 +1969,9 @@ func TestBuildPod_SessionTitleDeterministic(t *testing.T) {
 	pod := buildPod(task, "my-task-pod", cfg, nil, nil, nil, nil, defaultSystemConfig(), "")
 	container := pod.Spec.Containers[0]
 
-	// Should contain deterministic title format: kubeopencode/<namespace>/<task-name>
-	if !strings.Contains(container.Command[2], "'kubeopencode/default/my-task'") {
-		t.Errorf("Command --title should contain deterministic session title, got: %s", container.Command[2])
+	// Should contain unique title format: kubeopencode/<namespace>/<task-name>/<uid-prefix>
+	if !strings.Contains(container.Command[2], "'kubeopencode/default/my-task/test-uid") {
+		t.Errorf("Command --title should contain unique session title with UID prefix, got: %s", container.Command[2])
 	}
 }
 
@@ -2535,10 +2535,11 @@ func TestSessionTitle(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-task",
 			Namespace: "test-ns",
+			UID:       types.UID("abcdef12-3456-7890-abcd-ef1234567890"),
 		},
 	}
 	title := sessionTitle(task)
-	expected := "kubeopencode/test-ns/my-task"
+	expected := "kubeopencode/test-ns/my-task/abcdef12"
 	if title != expected {
 		t.Errorf("sessionTitle = %q, want %q", title, expected)
 	}
@@ -2547,6 +2548,14 @@ func TestSessionTitle(t *testing.T) {
 	title2 := sessionTitle(task)
 	if title != title2 {
 		t.Errorf("sessionTitle should be deterministic, got %q and %q", title, title2)
+	}
+
+	// Verify different UID produces different title
+	task2 := task.DeepCopy()
+	task2.UID = types.UID("99999999-0000-1111-2222-333344445555")
+	title3 := sessionTitle(task2)
+	if title == title3 {
+		t.Errorf("different UIDs should produce different titles, both got %q", title)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes incorrect session matching when a Task is deleted and recreated with the same name. The controller was resolving `task.status.session` to a stale (old) session instead of the one just executed.

**Root cause:** `sessionTitle()` generated `kubeopencode/<ns>/<name>` — identical for same-name Tasks. `FindSessionByTitle()` returned the first match (oldest session), not the latest.

**Fixes:**
- Include Task UID prefix in session title (`kubeopencode/<ns>/<name>/<uid-prefix>`) to guarantee uniqueness per Task object
- `FindSessionByTitle` now returns the most recently created session (by `Time.Created`) when multiple sessions match, as defense-in-depth
- Added unit tests for `FindSessionByTitle` covering duplicate titles, ordering, empty responses

**Files changed:**
- `internal/controller/opencode_client.go` — return latest session by timestamp
- `internal/controller/pod_builder.go` — append UID prefix to session title
- `internal/controller/opencode_client_test.go` — new test file for OpenCodeClient
- `internal/controller/pod_builder_test.go` — updated session title tests
- `docs/adr/0035-task-session-integration.md` — documented the fix

Reported by @shahrin in Slack.