### PR TITLE
feat(chart): add gateway api compatibility

### DIFF
--- a/charts/kubeopencode/templates/server/httproute.yaml
+++ b/charts/kubeopencode/templates/server/httproute.yaml
@@ -1,0 +1,46 @@
+{{- range $name, $route := .Values.server.route }}
+{{- if $route.enabled }}
+---
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ include "kubeopencode.fullname" $ }}-server
+  namespace: {{ include "kubeopencode.namespace" $ }}
+  labels:
+    {{ include "kubeopencode.server.labels" $ | nindent 4 }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $route.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames: {{ tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - backendRefs:
+        - name: {{ include "kubeopencode.fullname" $ }}-server
+          port: {{ $.Values.server.service.port }}
+      {{- with $route.filters }}
+      filters: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches: {{ toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/kubeopencode/values.yaml
+++ b/charts/kubeopencode/values.yaml
@@ -126,6 +126,58 @@ server:
     #    hosts:
     #      - kubeopencode.local
 
+    ## route (map) allows configuration of HTTPRoute resources
+    ## Requires Gateway API resources and suitable controller installed within the cluster
+    ## Ref. https://gateway-api.sigs.k8s.io/guides/http-routing/
+    ##
+    ## The agent proxy uses SSE (Server-Sent Events) for streaming. Depending on your
+    ## gateway controller, you may need to configure it to disable response buffering and
+    ## increase timeouts.
+    route:
+      main:
+        ## Enable this route
+        enabled: false
+
+        ## ApiVersion set by default to "gateway.networking.k8s.io/v1"
+        apiVersion: ""
+        ## kind set by default to HTTPRoute
+        kind: ""
+
+        ## Annotations to attach to the HTTPRoute resource
+        annotations: {}
+        ## Labels to attach to the HTTPRoute resource
+        labels: {}
+
+        ## ParentRefs refers to resources this HTTPRoute is to be attached to (Gateways)
+        parentRefs: []
+          # - name: contour
+          #   sectionName: http
+
+        ## Hostnames (templated) defines a set of hostnames that should match against
+        ## the HTTP Host header to select a HTTPRoute used to process the request
+        hostnames: []
+          # - my.example.com
+
+        ## additionalRules (templated) allows adding custom rules to the route
+        additionalRules: []
+
+        ## Filters define the filters that are applied to requests that match
+        ## this rule
+        filters: []
+
+        ## Matches define conditions used for matching the rule against incoming
+        ## HTTP requests
+        matches:
+          - path:
+              type: PathPrefix
+              value: /
+
+        ## httpsRedirect adds a filter for redirecting to https (HTTP 301 Moved Permanently).
+        ## To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners.
+        ## Matches and filters do not take effect if enabled.
+        ## Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
+        httpsRedirect: false
+
   # Resource limits and requests
   resources:
     limits:


### PR DESCRIPTION
## Summary
Added Gateway API compatibility to the KubeOpenCode Helm chart by introducing an HTTPRoute template (`charts/kubeopencode/templates/server/httproute.yaml`) and a route configuration block in `values.yaml`, allowing users to expose the server via a Gateway API-compatible controller instead of a traditional Ingress. A note is also included warning that SSE streaming may require additional gateway controller configuration (e.g. disabling response buffering and increasing timeouts).

## Related Issues
Fixes issue #165 

## Test Plan
- [x] Manual testing using [Envoy Gateway](https://gateway.envoyproxy.io)