### PR TITLE
fix(chart): fix Gateway API HTTPRoute values path and add documentation

### DIFF
--- a/charts/kubeopencode/README.md
+++ b/charts/kubeopencode/README.md
@@ -61,6 +61,28 @@ helm install kubeopencode oci://ghcr.io/kubeopencode/helm-charts/kubeopencode \
   --values my-values.yaml
 ```
 
+#### Using Gateway API (HTTPRoute)
+
+If your cluster uses the [Gateway API](https://gateway-api.sigs.k8s.io/) instead of Ingress:
+
+```yaml
+server:
+  enabled: true
+  route:
+    main:
+      enabled: true
+      parentRefs:
+        - name: my-gateway
+          namespace: gateway-system
+      hostnames:
+        - kubeopencode.example.com
+```
+
+> **Note:** The agent proxy uses SSE (Server-Sent Events) for streaming. Depending on your
+> gateway controller, you may need to disable response buffering and increase timeouts.
+> For example, with Envoy Gateway, add a [BackendTrafficPolicy](https://gateway.envoyproxy.io/docs/api/extension_types/#backendtrafficpolicy)
+> to configure timeouts.
+
 ## Configuration
 
 The following table lists the configurable parameters of the KubeOpenCode chart and their default values.
@@ -89,6 +111,10 @@ The following table lists the configurable parameters of the KubeOpenCode chart 
 | `server.auth.allowAnonymous` | Allow unauthenticated requests | `false` |
 | `server.ingress.enabled` | Enable Ingress | `false` |
 | `server.ingress.className` | Ingress class name | `""` |
+| `server.route.main.enabled` | Enable Gateway API HTTPRoute | `false` |
+| `server.route.main.parentRefs` | Gateway references for HTTPRoute | `[]` |
+| `server.route.main.hostnames` | Hostnames for HTTPRoute matching | `[]` |
+| `server.route.main.httpsRedirect` | Enable HTTPS redirect (HTTP 301) | `false` |
 | `server.portForward.enabled` | Create port-forward RBAC | `false` |
 
 ### Agent Configuration

--- a/charts/kubeopencode/templates/server/httproute.yaml
+++ b/charts/kubeopencode/templates/server/httproute.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.server.enabled }}
 {{- range $name, $route := .Values.server.route }}
 {{- if $route.enabled }}
 ---
@@ -40,7 +41,8 @@ spec:
       {{- end }}
       {{- with $route.matches }}
       matches: {{ toYaml . | nindent 8 }}
-      {{- end }}
-    {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kubeopencode/values.yaml
+++ b/charts/kubeopencode/values.yaml
@@ -97,7 +97,7 @@ server:
     port: 2746
 
   # Authentication configuration
-  # Enable when exposing the server externally (via Ingress) for agent proxy access.
+  # Enable when exposing the server externally (via Ingress or HTTPRoute) for agent proxy access.
   # Uses Kubernetes TokenReview to validate Bearer tokens from kubeconfig.
   auth:
     enabled: true
@@ -126,57 +126,57 @@ server:
     #    hosts:
     #      - kubeopencode.local
 
-    ## route (map) allows configuration of HTTPRoute resources
-    ## Requires Gateway API resources and suitable controller installed within the cluster
-    ## Ref. https://gateway-api.sigs.k8s.io/guides/http-routing/
-    ##
-    ## The agent proxy uses SSE (Server-Sent Events) for streaming. Depending on your
-    ## gateway controller, you may need to configure it to disable response buffering and
-    ## increase timeouts.
-    route:
-      main:
-        ## Enable this route
-        enabled: false
+  ## route (map) allows configuration of HTTPRoute resources
+  ## Requires Gateway API resources and suitable controller installed within the cluster
+  ## Ref. https://gateway-api.sigs.k8s.io/guides/http-routing/
+  ##
+  ## The agent proxy uses SSE (Server-Sent Events) for streaming. Depending on your
+  ## gateway controller, you may need to configure it to disable response buffering and
+  ## increase timeouts.
+  route:
+    main:
+      ## Enable this route
+      enabled: false
 
-        ## ApiVersion set by default to "gateway.networking.k8s.io/v1"
-        apiVersion: ""
-        ## kind set by default to HTTPRoute
-        kind: ""
+      ## ApiVersion set by default to "gateway.networking.k8s.io/v1"
+      apiVersion: ""
+      ## kind set by default to HTTPRoute
+      kind: ""
 
-        ## Annotations to attach to the HTTPRoute resource
-        annotations: {}
-        ## Labels to attach to the HTTPRoute resource
-        labels: {}
+      ## Annotations to attach to the HTTPRoute resource
+      annotations: {}
+      ## Labels to attach to the HTTPRoute resource
+      labels: {}
 
-        ## ParentRefs refers to resources this HTTPRoute is to be attached to (Gateways)
-        parentRefs: []
-          # - name: contour
-          #   sectionName: http
+      ## ParentRefs refers to resources this HTTPRoute is to be attached to (Gateways)
+      parentRefs: []
+        # - name: contour
+        #   sectionName: http
 
-        ## Hostnames (templated) defines a set of hostnames that should match against
-        ## the HTTP Host header to select a HTTPRoute used to process the request
-        hostnames: []
-          # - my.example.com
+      ## Hostnames (templated) defines a set of hostnames that should match against
+      ## the HTTP Host header to select a HTTPRoute used to process the request
+      hostnames: []
+        # - my.example.com
 
-        ## additionalRules (templated) allows adding custom rules to the route
-        additionalRules: []
+      ## additionalRules (templated) allows adding custom rules to the route
+      additionalRules: []
 
-        ## Filters define the filters that are applied to requests that match
-        ## this rule
-        filters: []
+      ## Filters define the filters that are applied to requests that match
+      ## this rule
+      filters: []
 
-        ## Matches define conditions used for matching the rule against incoming
-        ## HTTP requests
-        matches:
-          - path:
-              type: PathPrefix
-              value: /
+      ## Matches define conditions used for matching the rule against incoming
+      ## HTTP requests
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
 
-        ## httpsRedirect adds a filter for redirecting to https (HTTP 301 Moved Permanently).
-        ## To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners.
-        ## Matches and filters do not take effect if enabled.
-        ## Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
-        httpsRedirect: false
+      ## httpsRedirect adds a filter for redirecting to https (HTTP 301 Moved Permanently).
+      ## To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners.
+      ## Matches and filters do not take effect if enabled.
+      ## Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
+      httpsRedirect: false
 
   # Resource limits and requests
   resources:

--- a/deploy/local-dev/local-development.md
+++ b/deploy/local-dev/local-development.md
@@ -192,6 +192,22 @@ Add to `/etc/hosts`:
 127.0.0.1 kubeopencode.local
 ```
 
+#### Option 4: HTTPRoute (Gateway API)
+
+If your cluster has a [Gateway API](https://gateway-api.sigs.k8s.io/) controller installed:
+
+```bash
+helm upgrade kubeopencode ./charts/kubeopencode \
+  --namespace kubeopencode-system \
+  --set server.enabled=true \
+  --set server.route.main.enabled=true \
+  --set "server.route.main.parentRefs[0].name=my-gateway" \
+  --set "server.route.main.hostnames[0]=kubeopencode.local"
+```
+
+> **Note:** SSE streaming may require additional gateway controller configuration
+> (e.g., disabling response buffering and increasing timeouts).
+
 ### UI Features
 
 | Feature | Description |

--- a/website/docs/use-cases/agent-share-link.md
+++ b/website/docs/use-cases/agent-share-link.md
@@ -121,7 +121,7 @@ kubeoc agent share team-agent -n platform --show
 
 ### Networking
 
-- The share URL must be reachable by the consumer — ensure your Ingress or LoadBalancer exposes the KubeOpenCode server
+- The share URL must be reachable by the consumer — ensure your Ingress, HTTPRoute, or LoadBalancer exposes the KubeOpenCode server
 - The server port is `2746` by default
 - For local testing: `kubectl port-forward -n kubeopencode-system svc/kubeopencode-server 2746:2746`
 

--- a/website/docs/use-cases/vscode-in-browser.md
+++ b/website/docs/use-cases/vscode-in-browser.md
@@ -4,7 +4,7 @@ Run a full VS Code editor alongside your AI agent, accessible from any browser. 
 
 ## Overview
 
-[code-server](https://github.com/coder/code-server) by Coder runs VS Code as a web application inside a container. Combined with KubeOpenCode's [extraPorts](../features/pod-configuration.md#extra-ports) feature, you can expose the VS Code UI through the Agent's Service and access it via `kubectl port-forward` or Ingress.
+[code-server](https://github.com/coder/code-server) by Coder runs VS Code as a web application inside a container. Combined with KubeOpenCode's [extraPorts](../features/pod-configuration.md#extra-ports) feature, you can expose the VS Code UI through the Agent's Service and access it via `kubectl port-forward`, Ingress, or HTTPRoute.
 
 ```mermaid
 graph TB


### PR DESCRIPTION
## Summary

Follow-up fixes for #175 (Gateway API HTTPRoute support):

- **Bug fix**: Moved `route` config from `server.ingress.route` to `server.route` in `values.yaml` — the template reads `.Values.server.route` but the values were nested under `server.ingress.route`, making the feature non-functional with default values
- **Bug fix**: Added `server.enabled` guard to `httproute.yaml` — all other server templates check this, preventing creation of an HTTPRoute pointing to a non-existent Service
- **Docs**: Added `server.route.*` parameters to Helm chart README configuration table and Gateway API production example
- **Docs**: Added "Option 4: HTTPRoute (Gateway API)" to local-dev guide
- **Docs**: Updated Ingress-only mentions in website docs (`agent-share-link.md`, `vscode-in-browser.md`) to include HTTPRoute
- **Docs**: Updated auth comment in `values.yaml` to mention HTTPRoute

## Related Issues

Follow-up to #175, related to #165

## Test Plan

- [x] `yq eval` validates `values.yaml` syntax
- [x] `helm template` with `server.route.main.enabled=true` renders HTTPRoute correctly
- [x] `helm template` with `server.enabled=false` correctly skips HTTPRoute
- [x] `make build` passes