### PR TITLE
fix(chart): deprecate nginx-ingress annotations

### DIFF
--- a/charts/kubeopencode/values.yaml
+++ b/charts/kubeopencode/values.yaml
@@ -108,14 +108,10 @@ server:
   ingress:
     enabled: false
     className: ""
+    # The agent proxy uses SSE (Server-Sent Events) for streaming. Depending on your
+    # gateway controller, you may need to add annotations it to disable response buffering
+    # and increase timeouts.
     annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-    #
-    # Required for agent proxy (SSE streaming) with nginx ingress:
-    # nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    # nginx.ingress.kubernetes.io/proxy-buffering: "off"
-    # nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
     hosts:
       - host: kubeopencode.local
         paths:


### PR DESCRIPTION
## Summary
The `kubernetes/ingress-nginx` project has been archived and is no longer maintained. The Helm chart previously included nginx-specific annotations for SSE streaming support, which could mislead users into adopting an unsupported ingress controller.

This PR removes those nginx-specific annotations and replaces them with a generic note clarifying that SSE streaming requires response buffering to be disabled and a long read timeout to be set, with the appropriate annotations depending on the ingress controller being used.

## Related Issues
Fixes #176 