### PR TITLE
chore: release v0.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,7 +351,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.0.28
+- **Version**: v0.1.0
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= 0.0.28
+VERSION ?= 0.1.0
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.14.28
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= 0.0.28
+VERSION ?= 0.1.0
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.0.28
-appVersion: "v0.0.28"
+version: 0.1.0
+appVersion: "v0.1.0"
 keywords:
   - automation
   - ai-agent

--- a/hack/update-deepcopy.sh
+++ b/hack/update-deepcopy.sh
@@ -10,7 +10,7 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 cd "${SCRIPT_ROOT}"
 
 # Use controller-gen for deepcopy generation (simpler and more compatible)
-LOCALBIN="${SCRIPT_ROOT}/bin"
+LOCALBIN="$(cd "${SCRIPT_ROOT}" && pwd)/bin"
 CONTROLLER_GEN="${LOCALBIN}/controller-gen"
 
 # Ensure controller-gen is installed


### PR DESCRIPTION
## Summary

Prepare v0.1.0 release.

- Update VERSION to 0.1.0 in Makefile and agents/Makefile
- Update Chart.yaml version to 0.1.0 and appVersion to v0.1.0
- Update AGENTS.md project status version
- Fix update-deepcopy.sh to use absolute path for GOBIN