### PR TITLE
chore: unify image tag strategy for local-dev and e2e (all :dev)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,8 +126,10 @@ All Go files must include:
 The `deploy/local-dev/` directory contains **manifests and examples only** (AgentTemplate, Agents, RBAC, Kustomization). It does NOT contain setup instructions — those live in `CONTRIBUTING.md`.
 
 **Image tag workflow summary** (critical for debugging image pull errors):
-- Controller image: tagged as both `:<VERSION>` and `:latest`. Loaded into Kind as `:latest`. Helm must set `controller.image.tag=latest` and `server.image.tag=latest`.
-- Agent images: tagged as `:<VERSION>`, then re-tagged to `:dev` by the Makefile. Loaded into Kind as `:dev`. The `:latest` tag MUST NOT be used for agents in Kind (causes `ErrImagePull` due to `imagePullPolicy: Always`).
+- All images (controller, server, agents) use the `:dev` tag uniformly in Kind clusters. The `:latest` tag MUST NOT be used in Kind (causes `ErrImagePull` due to `imagePullPolicy: Always`).
+- Controller image: `docker-build` tags as `:<VERSION>`, `:latest`, and `:dev`. Loaded into Kind as `:dev`.
+- Agent images: tagged as `:<VERSION>`, then re-tagged to `:dev` by the Makefile. Loaded into Kind as `:dev`.
+- System image (git-init, context-init): overridden via `KubeOpenCodeConfig.spec.systemImage` to use `:dev` with `imagePullPolicy: Never` in Kind.
 - `imagePullPolicy` must be `Never` for all locally-built images in Kind.
 
 ## Development Workflow
@@ -165,12 +167,12 @@ make e2e-reload     # Rebuild + reload controller image + run e2e-test
 > ```bash
 > make local-dev-reload
 > ```
-> This rebuilds the image (with both `:VERSION` and `:latest` tags), loads into Kind, and restarts all deployments. Never manually run `docker-build` + `kind load` for local-dev — use `local-dev-reload` to avoid tag mismatches.
+> This rebuilds images (tagged `:dev`), loads into Kind, and restarts all deployments. Never manually run `docker-build` + `kind load` for local-dev — use `local-dev-reload` to avoid tag mismatches.
 >
-> **Known issue: Kind image cache stale after reload.** `make local-dev-reload` does `kind load docker-image` + `kubectl rollout restart`, but Kind nodes cache images by digest. If the `:latest` tag digest on the node matches, `kind load` skips the actual load. The restarted Pod then pulls the stale cached image. **Workaround:**
+> **Known issue: Kind image cache stale after reload.** `make local-dev-reload` does `kind load docker-image` + `kubectl rollout restart`, but Kind nodes cache images by digest. If the `:dev` tag digest on the node matches, `kind load` skips the actual load. The restarted Pod then pulls the stale cached image. **Workaround:**
 > ```bash
 > # 1. Tag with a unique name to force Kind to re-tag on the node
-> docker tag ghcr.io/kubeopencode/kubeopencode:latest ghcr.io/kubeopencode/kubeopencode:dev-$(date +%s)
+> docker tag ghcr.io/kubeopencode/kubeopencode:dev ghcr.io/kubeopencode/kubeopencode:dev-$(date +%s)
 > kind load docker-image ghcr.io/kubeopencode/kubeopencode:dev-$(date +%s) --name kubeopencode
 > # 2. Patch the deployment to use the new tag
 > kubectl set image deployment/kubeopencode-controller controller=ghcr.io/kubeopencode/kubeopencode:dev-$(date +%s) -n kubeopencode-system

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ make local-dev-setup
 This single command performs all of the steps below automatically:
 1. Creates a Kind cluster named `kubeopencode`
 2. Builds the controller image and all agent images
-3. Tags and loads images into Kind (controller as `:latest`, agents as `:dev`)
+3. Tags and loads all images into Kind with the `:dev` tag
 4. Installs via Helm with correct image tags and pull policies
 5. Deploys test resources (`deploy/local-dev/`) via Kustomize
 
@@ -198,8 +198,8 @@ make agent-build AGENT=attach      # Attach image (required for agentRef Tasks)
 #### 3. Load Images to Kind
 
 ```bash
-# Load controller image
-kind load docker-image ghcr.io/kubeopencode/kubeopencode:latest --name kubeopencode
+# Load controller image (use :dev tag, not :latest, to avoid PullAlways in Kind)
+kind load docker-image ghcr.io/kubeopencode/kubeopencode:dev --name kubeopencode
 
 # Tag and load all agent images with :dev tag
 for img in opencode devbox attach; do
@@ -208,7 +208,7 @@ for img in opencode devbox attach; do
 done
 ```
 
-> **Important: Avoid `:latest` tag for agent images.** The controller sets `imagePullPolicy: Always` for images with the `:latest` tag (standard Kubernetes convention). In Kind, this causes `ErrImagePull` because the cluster cannot pull from remote registries. The local-dev agent YAML files use the `:dev` tag to avoid this.
+> **Important: Avoid `:latest` tag in Kind clusters.** The controller sets `imagePullPolicy: Always` for images with the `:latest` tag (standard Kubernetes convention). In Kind, this causes `ErrImagePull` because the cluster cannot pull from remote registries. All local-dev images use the `:dev` tag to avoid this.
 
 #### 4. Deploy with Helm
 
@@ -216,15 +216,17 @@ done
 helm upgrade --install kubeopencode ./charts/kubeopencode \
   --namespace kubeopencode-system \
   --create-namespace \
-  --set controller.image.tag=latest \
+  --set controller.image.tag=dev \
   --set controller.image.pullPolicy=Never \
   --set agent.image.pullPolicy=Never \
   --set server.enabled=true \
-  --set server.image.tag=latest \
-  --set server.image.pullPolicy=Never
+  --set server.image.tag=dev \
+  --set server.image.pullPolicy=Never \
+  --set kubeopencodeConfig.systemImage.image=ghcr.io/kubeopencode/kubeopencode:dev \
+  --set kubeopencodeConfig.systemImage.imagePullPolicy=Never
 ```
 
-> **Important:** The Helm chart defaults to `v<VERSION>` image tags, but `make docker-build` tags images as `<VERSION>` (without `v` prefix) and `latest`. You must explicitly set `controller.image.tag=latest` and `server.image.tag=latest` to match locally built images. Without this, pods will fail with `ErrImageNeverPull`.
+> **Important:** All images in Kind must use the `:dev` tag with `imagePullPolicy=Never`. The `systemImage` override ensures init containers (git-init, context-init) also use the local `:dev` image instead of the default `:latest`.
 
 #### 5. Deploy Test Resources
 

--- a/Makefile
+++ b/Makefile
@@ -475,6 +475,8 @@ local-dev-setup: ## One-command local dev setup: cluster, images, helm, test res
 .PHONY: local-dev-setup
 
 local-dev-reload: ## Rebuild and reload all images into local dev cluster
+	@# Note: KubeOpenCodeConfig.systemImage is set during local-dev-setup via Helm
+	@# and persists across reloads. No need to re-run helm upgrade here.
 	@echo "=== Rebuilding and reloading images ==="
 	@$(MAKE) docker-build
 	@for agent in $(LOCAL_DEV_AGENTS); do \

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,8 @@ verify: check-env
 ##@ Docker
 
 # Build the docker image (includes UI build)
-# Always tags as both :VERSION and :latest so Kind/local-dev clusters work without extra steps
+# Tags as :VERSION, :latest, and :dev so Kind/local-dev clusters work without extra steps.
+# :latest is the production default; :dev is used in Kind clusters (avoids PullAlways).
 docker-build: ui-build
 	docker build \
 		--build-arg VERSION=$(VERSION) \
@@ -131,6 +132,7 @@ docker-build: ui-build
 		--build-arg BUILD_TIME=$(BUILD_DATE) \
 		-t $(IMG) \
 		-t $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):latest \
+		-t $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):dev \
 		.
 .PHONY: docker-build
 
@@ -295,13 +297,10 @@ e2e-docker-build: ## Build docker image for e2e testing
 .PHONY: e2e-docker-build
 
 # Load docker image into kind cluster
-# Also tags and loads :latest for init containers (git-init, save-session) that use DefaultKubeOpenCodeImage
+# System image (git-init, context-init) is overridden via KubeOpenCodeConfig in e2e-deploy,
+# so we only need to load the :dev tag — no :latest workaround needed.
 e2e-kind-load: ## Load docker image into kind cluster
 	kind load docker-image $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(E2E_IMG_TAG) --name $(E2E_CLUSTER_NAME)
-	@if [ "$(E2E_IMG_TAG)" != "latest" ]; then \
-		docker tag $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(E2E_IMG_TAG) $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):latest; \
-		kind load docker-image $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):latest --name $(E2E_CLUSTER_NAME); \
-	fi
 .PHONY: e2e-kind-load
 
 # Verify image in kind cluster
@@ -326,6 +325,8 @@ e2e-deploy: ## Deploy controller and CRDs to kind cluster using Helm
 		--set server.image.repository=$(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME) \
 		--set server.image.tag=$(E2E_IMG_TAG) \
 		--set server.image.pullPolicy=Never \
+		--set kubeopencodeConfig.systemImage.image=$(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(E2E_IMG_TAG) \
+		--set kubeopencodeConfig.systemImage.imagePullPolicy=Never \
 		--set webhook.enabled=true \
 		--set webhook.service.type=NodePort \
 		--set webhook.service.nodePort=30082 \
@@ -442,23 +443,25 @@ local-dev-setup: ## One-command local dev setup: cluster, images, helm, test res
 		echo "  Building agent: $$agent"; \
 		$(MAKE) agent-build AGENT=$$agent; \
 	done
-	@# Step 3: Load images into Kind
+	@# Step 3: Load images into Kind (all images use :dev tag uniformly)
 	@echo "[3/5] Loading images into Kind..."
-	@kind load docker-image $(LOCAL_DEV_CONTROLLER_IMG):latest --name $(LOCAL_DEV_CLUSTER)
+	@kind load docker-image $(LOCAL_DEV_CONTROLLER_IMG):$(LOCAL_DEV_IMG_TAG) --name $(LOCAL_DEV_CLUSTER)
 	@for img in $(LOCAL_DEV_AGENT_IMGS); do \
 		docker tag $$img:$(VERSION) $$img:$(LOCAL_DEV_IMG_TAG) 2>/dev/null || true; \
 		kind load docker-image $$img:$(LOCAL_DEV_IMG_TAG) --name $(LOCAL_DEV_CLUSTER); \
 	done
-	@# Step 4: Deploy with Helm
+	@# Step 4: Deploy with Helm (all images use :dev tag; systemImage overrides DefaultKubeOpenCodeImage for init containers)
 	@echo "[4/5] Deploying KubeOpenCode with Helm..."
 	@helm upgrade --install kubeopencode ./charts/kubeopencode \
 		--namespace kubeopencode-system \
 		--create-namespace \
 		--set controller.image.pullPolicy=Never \
-		--set controller.image.tag=latest \
+		--set controller.image.tag=$(LOCAL_DEV_IMG_TAG) \
 		--set agent.image.pullPolicy=Never \
 		--set server.enabled=true \
-		--set server.image.tag=latest \
+		--set server.image.tag=$(LOCAL_DEV_IMG_TAG) \
+		--set kubeopencodeConfig.systemImage.image=$(LOCAL_DEV_CONTROLLER_IMG):$(LOCAL_DEV_IMG_TAG) \
+		--set kubeopencodeConfig.systemImage.imagePullPolicy=Never \
 		--wait --timeout 120s
 	@# Step 5: Deploy local-dev test resources
 	@echo "[5/5] Deploying test resources..."
@@ -477,7 +480,7 @@ local-dev-reload: ## Rebuild and reload all images into local dev cluster
 	@for agent in $(LOCAL_DEV_AGENTS); do \
 		$(MAKE) agent-build AGENT=$$agent; \
 	done
-	@kind load docker-image $(LOCAL_DEV_CONTROLLER_IMG):latest --name $(LOCAL_DEV_CLUSTER)
+	@kind load docker-image $(LOCAL_DEV_CONTROLLER_IMG):$(LOCAL_DEV_IMG_TAG) --name $(LOCAL_DEV_CLUSTER)
 	@for img in $(LOCAL_DEV_AGENT_IMGS); do \
 		docker tag $$img:$(VERSION) $$img:$(LOCAL_DEV_IMG_TAG) 2>/dev/null || true; \
 		kind load docker-image $$img:$(LOCAL_DEV_IMG_TAG) --name $(LOCAL_DEV_CLUSTER); \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -298,7 +298,7 @@ echo "$GITHUB_TOKEN" | helm registry login ghcr.io -u $GITHUB_ACTOR --password-s
 
 ## Notes
 
-- The `DefaultKubeOpenCodeImage` in `internal/controller/pod_builder.go` stays as `:latest` intentionally. Users who want pinned versions configure it via `KubeOpenCodeConfig.spec.systemImage`.
+- The `DefaultKubeOpenCodeImage` in `internal/controller/pod_builder.go` stays as `:latest` intentionally. Users who want pinned versions configure it via `KubeOpenCodeConfig.spec.systemImage`. For local-dev (Kind), the Makefile sets `systemImage` to `:dev` via Helm to avoid `PullAlways`.
 - Agent image defaults (`DefaultAgentImage`, `DefaultExecutorImage`) also stay as `:latest`. Production users set explicit images in Agent CRDs.
 - No "development version" reset is needed after a release. The Go code defaults to `Version = "dev"` for untagged builds.
 - The `:latest` tag is also updated on every release, keeping it in sync with the most recent version.

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -41,8 +41,7 @@ var (
 
 	// agentImage is the OpenCode init container image used to copy the opencode
 	// binary to /tools. All E2E Agent/AgentTemplate specs must set AgentImage
-	// to this value to avoid the controller falling back to DefaultAgentImage
-	// (which uses :latest and triggers PullAlways in Kind).
+	// to this value to ensure the correct :dev-tagged image is used in Kind.
 	agentImage string
 
 	// OpenCode test configuration (for LabelOpenCode tests)

--- a/website/docs/operations/releasing.md
+++ b/website/docs/operations/releasing.md
@@ -272,7 +272,7 @@ echo "$GITHUB_TOKEN" | helm registry login ghcr.io -u $GITHUB_ACTOR --password-s
 
 ## Notes
 
-- The `DefaultKubeOpenCodeImage` in `internal/controller/pod_builder.go` stays as `:latest` intentionally. Users who want pinned versions configure it via `KubeOpenCodeConfig.spec.systemImage`.
+- The `DefaultKubeOpenCodeImage` in `internal/controller/pod_builder.go` stays as `:latest` intentionally. Users who want pinned versions configure it via `KubeOpenCodeConfig.spec.systemImage`. For local-dev (Kind), the Makefile sets `systemImage` to `:dev` via Helm to avoid `PullAlways`.
 - Agent image defaults (`DefaultAgentImage`, `DefaultExecutorImage`) also stay as `:latest`. Production users set explicit images in Agent CRDs.
 - No "development version" reset is needed after a release. The Go code defaults to `Version = "dev"` for untagged builds.
 - The `:latest` tag is also updated on every release, keeping it in sync with the most recent version.


### PR DESCRIPTION
## Summary

- Unify all Kind cluster images (controller, server, agents, system) to use `:dev` tag uniformly
- Override `KubeOpenCodeConfig.spec.systemImage` via Helm to use `:dev` with `imagePullPolicy: Never` in Kind
- Remove the `e2e-kind-load` workaround that loaded `:latest` alongside `:dev`

## Problem

In local-dev (Kind), the controller image used `:latest` while agent images used `:dev`. This inconsistency:
- Added cognitive overhead for developers
- Required a workaround in `e2e-kind-load` to tag/load `:latest` for system init containers
- Used different strategies for the same use case (local-dev vs e2e)

## Changes

| Component | Before | After |
|-----------|--------|-------|
| `docker-build` tags | `:VERSION` + `:latest` | `:VERSION` + `:latest` + `:dev` |
| local-dev controller tag | `:latest` | `:dev` |
| local-dev Helm `controller.image.tag` | `latest` | `dev` |
| local-dev Helm `systemImage` | *(not set)* | `:dev` + `Never` |
| e2e `systemImage` | *(not set, loaded :latest workaround)* | `:dev` + `Never` |
| e2e-kind-load | Load `:dev` + tag/load `:latest` | Load `:dev` only |

The Go constants (`DefaultKubeOpenCodeImage`, etc.) remain `:latest` intentionally — they are the production defaults. Local-dev and e2e override them via `KubeOpenCodeConfig.spec.systemImage`.

Fixes #188

/cc @jesusvico