### PR TITLE
fix: add tools volume mount to context-init when skills or plugins are configured

### DIFF
--- a/internal/controller/server_builder.go
+++ b/internal/controller/server_builder.go
@@ -322,7 +322,7 @@ func BuildServerDeployment(agent *kubeopenv1alpha1.Agent, agentCfg agentConfig, 
 		})
 
 		// Mount /tools volume so context-init can write config file
-		if !configIsEmpty(agentCfg.config) {
+		if !configIsEmpty(agentCfg.config) || len(agentCfg.skills) > 0 || hasServerPlugins(agentCfg.plugins) {
 			contextInit.VolumeMounts = append(contextInit.VolumeMounts, corev1.VolumeMount{
 				Name:      ToolsVolumeName,
 				MountPath: ToolsMountPath,


### PR DESCRIPTION
When an Agent specifies `.spec.skills`, the controller injects `skills.paths` into `opencode.json` and stores it in a ConfigMap. The `context-init` init container copies this file to `/tools/opencode.json`. However, the `/tools` volume mount was only added to `context-init` when inline config (`.spec.config`) was present. This caused `context-init` to write to its own ephemeral filesystem, making the config file unavailable to the `opencode-server` container.