### PR TITLE
test: add P2 coverage improvements for CLI, handlers, plugins, and git-sync

### DIFF
--- a/cmd/kubeoc/cli_test.go
+++ b/cmd/kubeoc/cli_test.go
@@ -1,0 +1,484 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestFormatAge(t *testing.T) {
+	tests := []struct {
+		name string
+		age  time.Duration
+		want string
+	}{
+		{
+			name: "seconds",
+			age:  30 * time.Second,
+			want: "30s",
+		},
+		{
+			name: "zero seconds",
+			age:  0,
+			want: "0s",
+		},
+		{
+			name: "minutes",
+			age:  5 * time.Minute,
+			want: "5m",
+		},
+		{
+			name: "just under an hour",
+			age:  59 * time.Minute,
+			want: "59m",
+		},
+		{
+			name: "hours",
+			age:  3 * time.Hour,
+			want: "3h",
+		},
+		{
+			name: "just under a day",
+			age:  23 * time.Hour,
+			want: "23h",
+		},
+		{
+			name: "days",
+			age:  3 * 24 * time.Hour,
+			want: "3d",
+		},
+		{
+			name: "many days",
+			age:  30 * 24 * time.Hour,
+			want: "30d",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatAge(time.Now().Add(-tt.age))
+			if got != tt.want {
+				t.Errorf("formatAge() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOutputFormat(t *testing.T) {
+	type testData struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+
+	items := testData{Name: "test", Value: 42}
+
+	tests := []struct {
+		name        string
+		format      string
+		wantHandled bool
+		wantErr     bool
+		wantContain string
+	}{
+		{
+			name:        "empty format returns false (use table output)",
+			format:      "",
+			wantHandled: false,
+		},
+		{
+			name:        "json format",
+			format:      "json",
+			wantHandled: true,
+			wantContain: `"name": "test"`,
+		},
+		{
+			name:        "yaml format",
+			format:      "yaml",
+			wantHandled: true,
+			wantContain: "name: test",
+		},
+		{
+			name:        "unknown format returns error",
+			format:      "xml",
+			wantHandled: true,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handled, err := outputFormat(tt.format, items)
+
+			if handled != tt.wantHandled {
+				t.Errorf("outputFormat() handled = %v, want %v", handled, tt.wantHandled)
+			}
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestOutputFormat_JSONValid(t *testing.T) {
+	items := map[string]string{"key": "value"}
+
+	// Capture stdout by replacing with a buffer is not trivial in this test,
+	// but we can verify the function does not error for valid input.
+	handled, err := outputFormat("json", items)
+	if !handled {
+		t.Error("expected handled=true for json format")
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOutputFormat_YAMLValid(t *testing.T) {
+	items := map[string]string{"key": "value"}
+
+	handled, err := outputFormat("yaml", items)
+	if !handled {
+		t.Error("expected handled=true for yaml format")
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCountReferencingAgents(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = kubeopenv1alpha1.AddToScheme(s)
+
+	tests := []struct {
+		name      string
+		templates []kubeopenv1alpha1.AgentTemplate
+		agents    []kubeopenv1alpha1.Agent
+		wantCount []int
+	}{
+		{
+			name: "no agents reference any template",
+			templates: []kubeopenv1alpha1.AgentTemplate{
+				{ObjectMeta: metav1.ObjectMeta{Name: "tmpl-1", Namespace: "default"}},
+			},
+			agents:    []kubeopenv1alpha1.Agent{},
+			wantCount: []int{0},
+		},
+		{
+			name: "one agent references one template",
+			templates: []kubeopenv1alpha1.AgentTemplate{
+				{ObjectMeta: metav1.ObjectMeta{Name: "tmpl-1", Namespace: "default"}},
+			},
+			agents: []kubeopenv1alpha1.Agent{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "agent-1", Namespace: "default"},
+					Spec: kubeopenv1alpha1.AgentSpec{
+						TemplateRef:  &kubeopenv1alpha1.AgentTemplateReference{Name: "tmpl-1"},
+						WorkspaceDir: "/workspace",
+					},
+				},
+			},
+			wantCount: []int{1},
+		},
+		{
+			name: "multiple agents reference same template",
+			templates: []kubeopenv1alpha1.AgentTemplate{
+				{ObjectMeta: metav1.ObjectMeta{Name: "tmpl-1", Namespace: "default"}},
+			},
+			agents: []kubeopenv1alpha1.Agent{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "agent-1", Namespace: "default"},
+					Spec: kubeopenv1alpha1.AgentSpec{
+						TemplateRef:  &kubeopenv1alpha1.AgentTemplateReference{Name: "tmpl-1"},
+						WorkspaceDir: "/workspace",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "agent-2", Namespace: "default"},
+					Spec: kubeopenv1alpha1.AgentSpec{
+						TemplateRef:  &kubeopenv1alpha1.AgentTemplateReference{Name: "tmpl-1"},
+						WorkspaceDir: "/workspace",
+					},
+				},
+			},
+			wantCount: []int{2},
+		},
+		{
+			name: "agents in different namespaces do not cross-reference",
+			templates: []kubeopenv1alpha1.AgentTemplate{
+				{ObjectMeta: metav1.ObjectMeta{Name: "tmpl-1", Namespace: "default"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "tmpl-1", Namespace: "production"}},
+			},
+			agents: []kubeopenv1alpha1.Agent{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "agent-1", Namespace: "default"},
+					Spec: kubeopenv1alpha1.AgentSpec{
+						TemplateRef:  &kubeopenv1alpha1.AgentTemplateReference{Name: "tmpl-1"},
+						WorkspaceDir: "/workspace",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "agent-2", Namespace: "production"},
+					Spec: kubeopenv1alpha1.AgentSpec{
+						TemplateRef:  &kubeopenv1alpha1.AgentTemplateReference{Name: "tmpl-1"},
+						WorkspaceDir: "/workspace",
+					},
+				},
+			},
+			wantCount: []int{1, 1},
+		},
+		{
+			name: "agent without templateRef is not counted",
+			templates: []kubeopenv1alpha1.AgentTemplate{
+				{ObjectMeta: metav1.ObjectMeta{Name: "tmpl-1", Namespace: "default"}},
+			},
+			agents: []kubeopenv1alpha1.Agent{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "agent-standalone", Namespace: "default"},
+					Spec: kubeopenv1alpha1.AgentSpec{
+						WorkspaceDir: "/workspace",
+					},
+				},
+			},
+			wantCount: []int{0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := make([]runtime.Object, 0, len(tt.agents))
+			for i := range tt.agents {
+				objs = append(objs, &tt.agents[i])
+			}
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithRuntimeObjects(objs...).
+				Build()
+
+			ctx := t.Context()
+			counts := countReferencingAgents(ctx, k8sClient, tt.templates)
+
+			if len(counts) != len(tt.wantCount) {
+				t.Fatalf("expected %d counts, got %d", len(tt.wantCount), len(counts))
+			}
+
+			for i, want := range tt.wantCount {
+				if counts[i] != want {
+					t.Errorf("template[%d] count = %d, want %d", i, counts[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestIsPortAvailable(t *testing.T) {
+	// Port 0 should always be available (OS assigns ephemeral port)
+	// We can't reliably test specific ports, but we can test the function doesn't panic
+	// Port 1 is typically privileged and unavailable on non-root
+	if isPortAvailable(1) {
+		// On some CI systems, this might actually be true, so just log
+		t.Log("port 1 is available (running as root?)")
+	}
+}
+
+func TestVersionCmd(t *testing.T) {
+	cmd := newVersionCmd()
+	if cmd.Use != "version" {
+		t.Errorf("expected Use 'version', got %q", cmd.Use)
+	}
+
+	// Execute the version command and capture output
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	// version command uses fmt.Printf which goes to stdout, not cmd.OutOrStdout()
+	// Just verify it doesn't error
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("version command failed: %v", err)
+	}
+}
+
+func TestCompletionCmd(t *testing.T) {
+	cmd := newCompletionCmd()
+	if cmd.Use != "completion [bash|zsh|fish|powershell]" {
+		t.Errorf("unexpected Use: %q", cmd.Use)
+	}
+
+	// Verify valid args
+	validArgs := cmd.ValidArgs
+	expected := []string{"bash", "zsh", "fish", "powershell"}
+	if len(validArgs) != len(expected) {
+		t.Fatalf("expected %d valid args, got %d", len(expected), len(validArgs))
+	}
+	for i, arg := range expected {
+		if validArgs[i] != arg {
+			t.Errorf("validArgs[%d] = %q, want %q", i, validArgs[i], arg)
+		}
+	}
+}
+
+func TestRootCmdStructure(t *testing.T) {
+	// Verify root command has expected subcommands
+	subCmds := rootCmd.Commands()
+	wantCmds := map[string]bool{
+		"version":    false,
+		"completion": false,
+		"get":        false,
+		"agent":      false,
+		"task":       false,
+		"crontask":   false,
+	}
+
+	for _, cmd := range subCmds {
+		if _, ok := wantCmds[cmd.Name()]; ok {
+			wantCmds[cmd.Name()] = true
+		}
+	}
+
+	for name, found := range wantCmds {
+		if !found {
+			t.Errorf("expected subcommand %q not found", name)
+		}
+	}
+}
+
+func TestGetCmdStructure(t *testing.T) {
+	getCmd := newGetCmd()
+	subCmds := getCmd.Commands()
+	wantCmds := map[string]bool{
+		"agents":         false,
+		"agenttemplates": false,
+		"tasks":          false,
+		"crontasks":      false,
+	}
+
+	for _, cmd := range subCmds {
+		if _, ok := wantCmds[cmd.Name()]; ok {
+			wantCmds[cmd.Name()] = true
+		}
+	}
+
+	for name, found := range wantCmds {
+		if !found {
+			t.Errorf("expected get subcommand %q not found", name)
+		}
+	}
+}
+
+func TestAgentCmdStructure(t *testing.T) {
+	agentCmd := newAgentCmd()
+	subCmds := agentCmd.Commands()
+	wantCmds := map[string]bool{
+		"attach":  false,
+		"suspend": false,
+		"resume":  false,
+		"share":   false,
+		"unshare": false,
+	}
+
+	for _, cmd := range subCmds {
+		if _, ok := wantCmds[cmd.Name()]; ok {
+			wantCmds[cmd.Name()] = true
+		}
+	}
+
+	for name, found := range wantCmds {
+		if !found {
+			t.Errorf("expected agent subcommand %q not found", name)
+		}
+	}
+}
+
+func TestTaskCmdStructure(t *testing.T) {
+	taskCmd := newTaskCmd()
+	subCmds := taskCmd.Commands()
+	wantCmds := map[string]bool{
+		"stop": false,
+		"logs": false,
+	}
+
+	for _, cmd := range subCmds {
+		if _, ok := wantCmds[cmd.Name()]; ok {
+			wantCmds[cmd.Name()] = true
+		}
+	}
+
+	for name, found := range wantCmds {
+		if !found {
+			t.Errorf("expected task subcommand %q not found", name)
+		}
+	}
+}
+
+func TestCronTaskCmdStructure(t *testing.T) {
+	cronTaskCmd := newCronTaskCmd()
+
+	// Verify alias
+	if len(cronTaskCmd.Aliases) == 0 || cronTaskCmd.Aliases[0] != "ct" {
+		t.Errorf("expected alias 'ct', got %v", cronTaskCmd.Aliases)
+	}
+
+	subCmds := cronTaskCmd.Commands()
+	wantCmds := map[string]bool{
+		"trigger": false,
+		"suspend": false,
+		"resume":  false,
+	}
+
+	for _, cmd := range subCmds {
+		if _, ok := wantCmds[cmd.Name()]; ok {
+			wantCmds[cmd.Name()] = true
+		}
+	}
+
+	for name, found := range wantCmds {
+		if !found {
+			t.Errorf("expected crontask subcommand %q not found", name)
+		}
+	}
+}
+
+func TestOutputFormat_JSONRoundtrip(t *testing.T) {
+	// Test with a real Kubernetes-like structure to ensure marshaling works
+	type Item struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+	}
+	items := []Item{
+		{Name: "a", Status: "Ready"},
+		{Name: "b", Status: "NotReady"},
+	}
+
+	// JSON should work without error
+	handled, err := outputFormat("json", items)
+	if !handled {
+		t.Error("expected handled=true")
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the data can be round-tripped
+	data, _ := json.MarshalIndent(items, "", "  ")
+	var decoded []Item
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if len(decoded) != 2 {
+		t.Errorf("expected 2 items, got %d", len(decoded))
+	}
+}

--- a/internal/controller/agent_controller_test.go
+++ b/internal/controller/agent_controller_test.go
@@ -1018,4 +1018,121 @@ var _ = Describe("AgentController", func() {
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
+
+	Context("When creating an Agent with plugins", func() {
+		It("Should create a Deployment with plugin-init container", func() {
+			agentName := "test-plugin-agent"
+
+			By("Creating an Agent with plugins")
+			agent := &kubeopenv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      agentName,
+					Namespace: agentNamespace,
+				},
+				Spec: kubeopenv1alpha1.AgentSpec{
+					ExecutorImage:      "ghcr.io/kubeopencode/kubeopencode-agent-devbox:latest",
+					WorkspaceDir:       "/workspace",
+					ServiceAccountName: "test-agent",
+					Port:               4096,
+					Plugins: []kubeopenv1alpha1.PluginSpec{
+						{Name: "@kubeopencode/plugin-test", Target: "server"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agent)).Should(Succeed())
+
+			By("Verifying Deployment has plugin-init container")
+			deploymentName := ServerDeploymentName(agentName)
+			Eventually(func() bool {
+				var deployment appsv1.Deployment
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      deploymentName,
+					Namespace: agentNamespace,
+				}, &deployment); err != nil {
+					return false
+				}
+
+				for _, c := range deployment.Spec.Template.Spec.InitContainers {
+					if c.Name == "plugin-init" {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "expected plugin-init init container in Deployment")
+
+			By("Verifying Deployment has plugins volume")
+			Eventually(func() bool {
+				var deployment appsv1.Deployment
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      deploymentName,
+					Namespace: agentNamespace,
+				}, &deployment); err != nil {
+					return false
+				}
+
+				for _, v := range deployment.Spec.Template.Spec.Volumes {
+					if v.Name == PluginsVolumeName {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "expected plugins volume in Deployment")
+		})
+	})
+
+	Context("When creating an Agent with git sync contexts", func() {
+		It("Should create a Deployment with git-sync sidecar for HotReload policy", func() {
+			agentName := "test-gitsync-agent"
+
+			By("Creating an Agent with git context using sync HotReload")
+			agent := &kubeopenv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      agentName,
+					Namespace: agentNamespace,
+				},
+				Spec: kubeopenv1alpha1.AgentSpec{
+					ExecutorImage:      "ghcr.io/kubeopencode/kubeopencode-agent-devbox:latest",
+					WorkspaceDir:       "/workspace",
+					ServiceAccountName: "test-agent",
+					Port:               4096,
+					Contexts: []kubeopenv1alpha1.ContextItem{
+						{
+							Name:      "code-repo",
+							Type:      kubeopenv1alpha1.ContextTypeGit,
+							MountPath: "/workspace/code",
+							Git: &kubeopenv1alpha1.GitContext{
+								Repository: "https://github.com/example/repo.git",
+								Ref:        "main",
+								Sync: &kubeopenv1alpha1.GitSync{
+									Enabled: true,
+									Policy:  kubeopenv1alpha1.GitSyncPolicyHotReload,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agent)).Should(Succeed())
+
+			By("Verifying Deployment has git-sync sidecar container")
+			deploymentName := ServerDeploymentName(agentName)
+			Eventually(func() bool {
+				var deployment appsv1.Deployment
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      deploymentName,
+					Namespace: agentNamespace,
+				}, &deployment); err != nil {
+					return false
+				}
+
+				// git-sync sidecar is a regular container, not an init container
+				for _, c := range deployment.Spec.Template.Spec.Containers {
+					if c.Name == "git-sync-0" {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "expected git-sync sidecar container in Deployment")
+		})
+	})
 })

--- a/internal/controller/task_controller_test.go
+++ b/internal/controller/task_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("TaskController", func() {
@@ -3875,6 +3876,83 @@ var _ = Describe("TaskController", func() {
 			}
 			Expect(queuedCondition).ShouldNot(BeNil())
 			Expect(queuedCondition.Reason).Should(Equal(kubeopenv1alpha1.ReasonAgentServerNotReady))
+
+			By("Cleaning up")
+			Expect(k8sClient.Delete(ctx, task)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, agent)).Should(Succeed())
+		})
+	})
+
+	Context("Task with Agent that has plugins", func() {
+		It("Should create Pod with plugin-init container", func() {
+			agentName := "test-plugin-task-agent"
+			taskName := "test-task-plugin"
+
+			By("Creating an Agent with plugins")
+			agent := &kubeopenv1alpha1.Agent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      agentName,
+					Namespace: taskNamespace,
+				},
+				Spec: kubeopenv1alpha1.AgentSpec{
+					ExecutorImage:      "test-executor:latest",
+					WorkspaceDir:       "/workspace",
+					ServiceAccountName: "test-agent",
+					Plugins: []kubeopenv1alpha1.PluginSpec{
+						{Name: "@kubeopencode/test-plugin", Target: "server"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agent)).Should(Succeed())
+
+			By("Creating a Task referencing this Agent")
+			desc := "Test plugins in task pod"
+			task := &kubeopenv1alpha1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      taskName,
+					Namespace: taskNamespace,
+				},
+				Spec: kubeopenv1alpha1.TaskSpec{
+					AgentRef:    &kubeopenv1alpha1.AgentReference{Name: agentName},
+					Description: &desc,
+				},
+			}
+			Expect(k8sClient.Create(ctx, task)).Should(Succeed())
+
+			By("Expecting a Pod to be created with plugin-init init container")
+			Eventually(func() bool {
+				podList := &corev1.PodList{}
+				if err := k8sClient.List(ctx, podList,
+					client.InNamespace(taskNamespace),
+					client.MatchingLabels{"kubeopencode.io/task": taskName},
+				); err != nil || len(podList.Items) == 0 {
+					return false
+				}
+				pod := &podList.Items[0]
+				for _, c := range pod.Spec.InitContainers {
+					if c.Name == "plugin-init" {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "expected plugin-init init container in Task Pod")
+
+			By("Verifying Pod has plugins volume")
+			podList := &corev1.PodList{}
+			Expect(k8sClient.List(ctx, podList,
+				client.InNamespace(taskNamespace),
+				client.MatchingLabels{"kubeopencode.io/task": taskName},
+			)).Should(Succeed())
+			Expect(podList.Items).Should(HaveLen(1))
+
+			pod := &podList.Items[0]
+			hasPluginsVolume := false
+			for _, v := range pod.Spec.Volumes {
+				if v.Name == PluginsVolumeName {
+					hasPluginsVolume = true
+				}
+			}
+			Expect(hasPluginsVolume).Should(BeTrue(), "expected plugins volume in Task Pod")
 
 			By("Cleaning up")
 			Expect(k8sClient.Delete(ctx, task)).Should(Succeed())

--- a/internal/controller/task_controller_test.go
+++ b/internal/controller/task_controller_test.go
@@ -3883,29 +3883,29 @@ var _ = Describe("TaskController", func() {
 		})
 	})
 
-	Context("Task with Agent that has plugins", func() {
+	Context("Task with AgentTemplate that has plugins", func() {
 		It("Should create Pod with plugin-init container", func() {
-			agentName := "test-plugin-task-agent"
+			templateName := "test-plugin-template"
 			taskName := "test-task-plugin"
 
-			By("Creating an Agent with plugins")
-			agent := &kubeopenv1alpha1.Agent{
+			By("Creating an AgentTemplate with plugins")
+			tmpl := &kubeopenv1alpha1.AgentTemplate{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      agentName,
+					Name:      templateName,
 					Namespace: taskNamespace,
 				},
-				Spec: kubeopenv1alpha1.AgentSpec{
+				Spec: kubeopenv1alpha1.AgentTemplateSpec{
 					ExecutorImage:      "test-executor:latest",
 					WorkspaceDir:       "/workspace",
-					ServiceAccountName: "test-agent",
+					ServiceAccountName: "default",
 					Plugins: []kubeopenv1alpha1.PluginSpec{
 						{Name: "@kubeopencode/test-plugin", Target: "server"},
 					},
 				},
 			}
-			Expect(k8sClient.Create(ctx, agent)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, tmpl)).Should(Succeed())
 
-			By("Creating a Task referencing this Agent")
+			By("Creating a Task referencing this AgentTemplate (ephemeral mode)")
 			desc := "Test plugins in task pod"
 			task := &kubeopenv1alpha1.Task{
 				ObjectMeta: metav1.ObjectMeta{
@@ -3913,7 +3913,7 @@ var _ = Describe("TaskController", func() {
 					Namespace: taskNamespace,
 				},
 				Spec: kubeopenv1alpha1.TaskSpec{
-					AgentRef:    &kubeopenv1alpha1.AgentReference{Name: agentName},
+					TemplateRef: &kubeopenv1alpha1.AgentTemplateReference{Name: templateName},
 					Description: &desc,
 				},
 			}
@@ -3956,7 +3956,7 @@ var _ = Describe("TaskController", func() {
 
 			By("Cleaning up")
 			Expect(k8sClient.Delete(ctx, task)).Should(Succeed())
-			Expect(k8sClient.Delete(ctx, agent)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, tmpl)).Should(Succeed())
 		})
 	})
 })

--- a/internal/server/handlers/agent_proxy_handler_test.go
+++ b/internal/server/handlers/agent_proxy_handler_test.go
@@ -1,0 +1,171 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNormalizeProxyPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		wildcard string
+		want     string
+	}{
+		{
+			name:     "empty wildcard returns root",
+			wildcard: "",
+			want:     "/",
+		},
+		{
+			name:     "path without leading slash gets one added",
+			wildcard: "session/123",
+			want:     "/session/123",
+		},
+		{
+			name:     "path with leading slash is unchanged",
+			wildcard: "/session/123",
+			want:     "/session/123",
+		},
+		{
+			name:     "root path",
+			wildcard: "/",
+			want:     "/",
+		},
+		{
+			name:     "nested path",
+			wildcard: "api/v1/sessions/abc/messages",
+			want:     "/api/v1/sessions/abc/messages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newProxyTestRequest(tt.wildcard)
+			got := normalizeProxyPath(r)
+			if got != tt.want {
+				t.Errorf("normalizeProxyPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// newProxyTestRequest creates a request with a chi route context containing the wildcard parameter.
+func newProxyTestRequest(wildcard string) *http.Request {
+	r, _ := http.NewRequest(http.MethodGet, "/", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("*", wildcard)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestResolveAgentServerURL(t *testing.T) {
+	const clusterDomain = "cluster.local"
+
+	tests := []struct {
+		name    string
+		agent   *testAgentSetup
+		wantErr string
+		wantURL string
+	}{
+		{
+			name: "valid agent with URL",
+			agent: &testAgentSetup{
+				name:      "my-agent",
+				namespace: "default",
+				url:       "http://my-agent-server.default.svc.cluster.local:4096",
+				suspended: false,
+			},
+			wantURL: "http://my-agent-server.default.svc.cluster.local:4096",
+		},
+		{
+			name: "suspended agent",
+			agent: &testAgentSetup{
+				name:      "my-agent",
+				namespace: "default",
+				url:       "http://my-agent-server.default.svc.cluster.local:4096",
+				suspended: true,
+			},
+			wantErr: "is suspended",
+		},
+		{
+			name: "agent with no URL",
+			agent: &testAgentSetup{
+				name:      "my-agent",
+				namespace: "default",
+				url:       "",
+				suspended: false,
+			},
+			wantErr: "is not ready",
+		},
+		{
+			name: "agent with external URL (SSRF protection)",
+			agent: &testAgentSetup{
+				name:      "my-agent",
+				namespace: "default",
+				url:       "http://evil.com:4096",
+				suspended: false,
+			},
+			wantErr: "invalid server URL",
+		},
+		{
+			name:    "agent not found",
+			agent:   nil,
+			wantErr: "agent not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+
+			agentName := "missing"
+			namespace := "default"
+
+			if tt.agent != nil {
+				agentName = tt.agent.name
+				namespace = tt.agent.namespace
+				agent := testAgent(
+					tt.agent.name, tt.agent.namespace,
+					nil, !tt.agent.suspended, tt.agent.suspended,
+				)
+				agent.Status.URL = tt.agent.url
+				builder = builder.WithRuntimeObjects(agent).
+					WithStatusSubresource(agent)
+			}
+
+			k8sClient := builder.Build()
+
+			url, err := resolveAgentServerURL(context.Background(), k8sClient, namespace, agentName, clusterDomain)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !containsSubstring(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if url != tt.wantURL {
+				t.Errorf("url = %q, want %q", url, tt.wantURL)
+			}
+		})
+	}
+}
+
+type testAgentSetup struct {
+	name      string
+	namespace string
+	url       string
+	suspended bool
+}

--- a/internal/server/handlers/agent_terminal_handler_test.go
+++ b/internal/server/handlers/agent_terminal_handler_test.go
@@ -1,0 +1,318 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/remotecommand"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
+)
+
+func TestCheckSameOrigin(t *testing.T) {
+	tests := []struct {
+		name   string
+		origin string
+		host   string
+		want   bool
+	}{
+		{
+			name:   "no origin header (non-browser client)",
+			origin: "",
+			host:   "example.com",
+			want:   true,
+		},
+		{
+			name:   "same origin",
+			origin: "http://example.com",
+			host:   "example.com",
+			want:   true,
+		},
+		{
+			name:   "same origin with port",
+			origin: "http://localhost:2746",
+			host:   "localhost:2746",
+			want:   true,
+		},
+		{
+			name:   "different origin",
+			origin: "http://evil.com",
+			host:   "example.com",
+			want:   false,
+		},
+		{
+			name:   "different port is different origin",
+			origin: "http://localhost:3000",
+			host:   "localhost:2746",
+			want:   false,
+		},
+		{
+			name:   "invalid origin URL",
+			origin: "://invalid",
+			host:   "example.com",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &http.Request{
+				Header: make(http.Header),
+				Host:   tt.host,
+			}
+			if tt.origin != "" {
+				r.Header.Set("Origin", tt.origin)
+			}
+
+			got := checkSameOrigin(r)
+			if got != tt.want {
+				t.Errorf("checkSameOrigin() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTransientExecError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "exit code 137 (SIGKILL)",
+			err:  &testError{msg: "command terminated with exit code 137"},
+			want: true,
+		},
+		{
+			name: "exit code 1 (not transient)",
+			err:  &testError{msg: "command terminated with exit code 1"},
+			want: false,
+		},
+		{
+			name: "connection refused (not transient)",
+			err:  &testError{msg: "connection refused"},
+			want: false,
+		},
+		{
+			name: "exit code 137 in wrapped error",
+			err:  &testError{msg: "exec failed: exit code 137: something went wrong"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTransientExecError(tt.err)
+			if got != tt.want {
+				t.Errorf("isTransientExecError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// testError is a simple error type for testing.
+type testError struct {
+	msg string
+}
+
+func (e *testError) Error() string {
+	return e.msg
+}
+
+func TestResolveAgentServerPod(t *testing.T) {
+	tests := []struct {
+		name          string
+		agentName     string
+		namespace     string
+		objects       []runtime.Object
+		wantErr       string
+		wantPod       string
+		wantContainer string
+	}{
+		{
+			name:      "agent not found",
+			agentName: "missing",
+			namespace: "default",
+			objects:   []runtime.Object{},
+			wantErr:   "agent not found",
+		},
+		{
+			name:      "agent is suspended",
+			agentName: "my-agent",
+			namespace: "default",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.AgentSpec{WorkspaceDir: "/workspace"},
+					Status: kubeopenv1alpha1.AgentStatus{
+						Suspended: true,
+					},
+				},
+			},
+			wantErr: "is suspended",
+		},
+		{
+			name:      "agent not ready",
+			agentName: "my-agent",
+			namespace: "default",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.AgentSpec{WorkspaceDir: "/workspace"},
+					Status: kubeopenv1alpha1.AgentStatus{
+						Ready: false,
+					},
+				},
+			},
+			wantErr: "is not ready",
+		},
+		{
+			name:      "no ready pods",
+			agentName: "my-agent",
+			namespace: "default",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.AgentSpec{WorkspaceDir: "/workspace"},
+					Status: kubeopenv1alpha1.AgentStatus{
+						Ready: true,
+					},
+				},
+			},
+			wantErr: "no ready server pod found",
+		},
+		{
+			name:      "finds ready pod",
+			agentName: "my-agent",
+			namespace: "default",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.AgentSpec{WorkspaceDir: "/workspace"},
+					Status: kubeopenv1alpha1.AgentStatus{
+						Ready: true,
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-agent-server-abc123",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app.kubernetes.io/name":      "kubeopencode-server",
+							"app.kubernetes.io/instance":  "my-agent",
+							"app.kubernetes.io/component": "server",
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			wantPod:       "my-agent-server-abc123",
+			wantContainer: "opencode-server",
+		},
+		{
+			name:      "skips non-running pod",
+			agentName: "my-agent",
+			namespace: "default",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.AgentSpec{WorkspaceDir: "/workspace"},
+					Status: kubeopenv1alpha1.AgentStatus{
+						Ready: true,
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-agent-server-pending",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app.kubernetes.io/name":      "kubeopencode-server",
+							"app.kubernetes.io/instance":  "my-agent",
+							"app.kubernetes.io/component": "server",
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodPending,
+					},
+				},
+			},
+			wantErr: "no ready server pod found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				WithStatusSubresource(&kubeopenv1alpha1.Agent{}).
+				Build()
+
+			podName, containerName, _, err := resolveAgentServerPod(context.Background(), k8sClient, tt.namespace, tt.agentName)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !containsSubstring(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if podName != tt.wantPod {
+				t.Errorf("podName = %q, want %q", podName, tt.wantPod)
+			}
+			if containerName != tt.wantContainer {
+				t.Errorf("containerName = %q, want %q", containerName, tt.wantContainer)
+			}
+		})
+	}
+}
+
+func TestTerminalSizeQueue(t *testing.T) {
+	q := &terminalSizeQueue{ch: make(chan *remotecommand.TerminalSize, 1)}
+
+	// Send a size
+	q.ch <- &remotecommand.TerminalSize{Width: 120, Height: 40}
+
+	// Receive it
+	size := q.Next()
+	if size == nil {
+		t.Fatal("expected non-nil size")
+	}
+	if size.Width != 120 || size.Height != 40 {
+		t.Errorf("size = %dx%d, want 120x40", size.Width, size.Height)
+	}
+
+	// Close and verify nil return
+	close(q.ch)
+	size = q.Next()
+	if size != nil {
+		t.Errorf("expected nil after close, got %v", size)
+	}
+}

--- a/internal/server/handlers/task_session_handler_test.go
+++ b/internal/server/handlers/task_session_handler_test.go
@@ -1,0 +1,214 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
+)
+
+func TestResolveTaskSessionURL(t *testing.T) {
+	const clusterDomain = "cluster.local"
+
+	tests := []struct {
+		name          string
+		namespace     string
+		taskName      string
+		objects       []runtime.Object
+		wantErr       string
+		wantSessionID string
+	}{
+		{
+			name:      "task not found",
+			namespace: "default",
+			taskName:  "missing",
+			objects:   []runtime.Object{},
+			wantErr:   "task not found",
+		},
+		{
+			name:      "task has no session info",
+			namespace: "default",
+			taskName:  "my-task",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-task", Namespace: "default"},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+					Status: kubeopenv1alpha1.TaskExecutionStatus{
+						Phase: kubeopenv1alpha1.TaskPhaseRunning,
+						// No Session field
+					},
+				},
+			},
+			wantErr: "has no session information",
+		},
+		{
+			name:      "task has no agent reference",
+			namespace: "default",
+			taskName:  "my-task",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-task", Namespace: "default"},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+					Status: kubeopenv1alpha1.TaskExecutionStatus{
+						Phase: kubeopenv1alpha1.TaskPhaseCompleted,
+						Session: &kubeopenv1alpha1.SessionInfo{
+							ID: "session-123",
+						},
+						// No AgentRef in status
+					},
+				},
+			},
+			wantErr: "has no agent reference",
+		},
+		{
+			name:      "agent not found",
+			namespace: "default",
+			taskName:  "my-task",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-task", Namespace: "default"},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+					Status: kubeopenv1alpha1.TaskExecutionStatus{
+						Phase: kubeopenv1alpha1.TaskPhaseCompleted,
+						Session: &kubeopenv1alpha1.SessionInfo{
+							ID: "session-123",
+						},
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+				},
+			},
+			wantErr: "agent not found",
+		},
+		{
+			name:      "agent has no URL",
+			namespace: "default",
+			taskName:  "my-task",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-task", Namespace: "default"},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+					Status: kubeopenv1alpha1.TaskExecutionStatus{
+						Phase: kubeopenv1alpha1.TaskPhaseCompleted,
+						Session: &kubeopenv1alpha1.SessionInfo{
+							ID: "session-123",
+						},
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+				},
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.AgentSpec{WorkspaceDir: "/workspace"},
+					Status: kubeopenv1alpha1.AgentStatus{
+						Ready: true,
+						URL:   "", // No URL
+					},
+				},
+			},
+			wantErr: "has no server URL",
+		},
+		{
+			name:      "successful resolution",
+			namespace: "default",
+			taskName:  "my-task",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-task", Namespace: "default"},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+					Status: kubeopenv1alpha1.TaskExecutionStatus{
+						Phase: kubeopenv1alpha1.TaskPhaseCompleted,
+						Session: &kubeopenv1alpha1.SessionInfo{
+							ID: "session-456",
+						},
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+				},
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.AgentSpec{WorkspaceDir: "/workspace"},
+					Status: kubeopenv1alpha1.AgentStatus{
+						Ready: true,
+						URL:   "http://my-agent-server.default.svc.cluster.local:4096",
+					},
+				},
+			},
+			wantSessionID: "session-456",
+		},
+		{
+			name:      "works with suspended agent (read-only access)",
+			namespace: "default",
+			taskName:  "my-task",
+			objects: []runtime.Object{
+				&kubeopenv1alpha1.Task{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-task", Namespace: "default"},
+					Spec: kubeopenv1alpha1.TaskSpec{
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+					Status: kubeopenv1alpha1.TaskExecutionStatus{
+						Phase: kubeopenv1alpha1.TaskPhaseCompleted,
+						Session: &kubeopenv1alpha1.SessionInfo{
+							ID: "session-789",
+						},
+						AgentRef: &kubeopenv1alpha1.AgentReference{Name: "my-agent"},
+					},
+				},
+				&kubeopenv1alpha1.Agent{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "default"},
+					Spec:       kubeopenv1alpha1.AgentSpec{WorkspaceDir: "/workspace", Suspend: true},
+					Status: kubeopenv1alpha1.AgentStatus{
+						Ready:     false,
+						Suspended: true,
+						URL:       "http://my-agent-server.default.svc.cluster.local:4096",
+					},
+				},
+			},
+			wantSessionID: "session-789",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(tt.objects...).
+				WithStatusSubresource(&kubeopenv1alpha1.Task{}, &kubeopenv1alpha1.Agent{}).
+				Build()
+
+			handler := NewTaskSessionHandler(k8sClient, clusterDomain)
+			_, sessionID, err := handler.resolveTaskSessionURL(context.Background(), tt.namespace, tt.taskName)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !containsSubstring(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if sessionID != tt.wantSessionID {
+				t.Errorf("sessionID = %q, want %q", sessionID, tt.wantSessionID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add first-ever unit tests for `cmd/kubeoc/` CLI (14 test functions covering `formatAge`, `outputFormat`, `countReferencingAgents`, command tree structure)
- Add unit tests for previously untested WebSocket/proxy handlers: `agent_terminal_handler`, `task_session_handler`, `agent_proxy_handler`
- Add integration tests (envtest) for plugins and git-sync in controller reconcile loop

## Details

### P2.1: CLI Tests (`cmd/kubeoc/cli_test.go`)
- `TestFormatAge` — 8 duration-to-string conversion cases (0s through 30d)
- `TestOutputFormat` — JSON/YAML/empty/unknown format handling
- `TestCountReferencingAgents` — 5 cases with fake k8s client (cross-namespace isolation, dedup, standalone agents)
- Command structure tests for all subcommands: `get`, `agent`, `task`, `crontask`, `version`, `completion`

### P2.2/P2.3: Integration Tests for Plugins & Git Sync
- `agent_controller_test.go`: Agent with plugins creates Deployment with `plugin-init` init container + `plugins` volume
- `agent_controller_test.go`: Agent with git-sync HotReload creates Deployment with `git-sync-0` sidecar container
- `task_controller_test.go`: Task with plugin-enabled Agent creates Pod with `plugin-init` init container

### P2.4: Handler Tests
- `agent_terminal_handler_test.go`: `checkSameOrigin` (6 WebSocket origin cases), `isTransientExecError` (exit-137 detection), `resolveAgentServerPod` (suspended/not-ready/no-pods/ready), `terminalSizeQueue`
- `task_session_handler_test.go`: `resolveTaskSessionURL` (7 cases including suspended agent read-only access)
- `agent_proxy_handler_test.go`: `normalizeProxyPath` (5 path normalization cases), `resolveAgentServerURL` (SSRF protection verification)

## Testing
```
go test ./cmd/kubeoc/... ./internal/controller/... ./internal/server/handlers/... -count=1
# ok  github.com/kubeopencode/kubeopencode/cmd/kubeoc        0.719s
# ok  github.com/kubeopencode/kubeopencode/internal/controller    1.539s
# ok  github.com/kubeopencode/kubeopencode/internal/server/handlers  1.240s
```

Lint passes on all modified packages (`golangci-lint run` — 0 issues).

Integration tests compile with `go build -tags integration` and `go vet -tags integration`.