### PR TITLE
feat(ui): refactor all detail pages to tab layout and enhance share link

### DIFF
--- a/internal/server/handlers/share_handler.go
+++ b/internal/server/handlers/share_handler.go
@@ -188,11 +188,16 @@ func (h *ShareHandler) ServeShareInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, servertypes.ShareInfoResponse{
+	resp := servertypes.ShareInfoResponse{
 		AgentName: sc.agent.Name,
 		Namespace: sc.agent.Namespace,
 		Profile:   sc.agent.Spec.Profile,
-	})
+	}
+	if sc.agent.Spec.Share != nil && sc.agent.Spec.Share.ExpiresAt != nil {
+		t := sc.agent.Spec.Share.ExpiresAt.Time.UTC().Format("2006-01-02T15:04:05Z")
+		resp.ExpiresAt = &t
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // ServeShareTerminal handles WebSocket terminal sessions via share token.

--- a/internal/server/types/types.go
+++ b/internal/server/types/types.go
@@ -414,9 +414,10 @@ type UpdateShareRequest struct {
 
 // ShareInfoResponse represents agent info returned for share link pages
 type ShareInfoResponse struct {
-	AgentName string `json:"agentName"`
-	Namespace string `json:"namespace"`
-	Profile   string `json:"profile,omitempty"`
+	AgentName string  `json:"agentName"`
+	Namespace string  `json:"namespace"`
+	Profile   string  `json:"profile,omitempty"`
+	ExpiresAt *string `json:"expiresAt,omitempty"`
 }
 
 // ShareStatusInfo represents share configuration in API responses

--- a/ui/src/components/LogViewer.tsx
+++ b/ui/src/components/LogViewer.tsx
@@ -152,7 +152,7 @@ function LogViewer({ namespace, taskName, podName, isRunning }: LogViewerProps) 
 
   const logAreaClass = isFullscreen
     ? 'flex-1 overflow-y-auto font-mono text-xs text-stone-300 whitespace-pre-wrap p-4 sidebar-scroll'
-    : 'p-4 h-96 overflow-y-auto font-mono text-xs text-stone-300 whitespace-pre-wrap sidebar-scroll';
+    : 'p-4 overflow-y-auto font-mono text-xs text-stone-300 whitespace-pre-wrap sidebar-scroll';
 
   return (
     <div className={containerClass}>
@@ -238,6 +238,7 @@ function LogViewer({ namespace, taskName, podName, isRunning }: LogViewerProps) 
         ref={logContainerRef}
         onScroll={handleScroll}
         className={logAreaClass}
+        style={isFullscreen ? undefined : { height: 'calc(100vh - 320px)', minHeight: '300px' }}
       >
         {logs.length === 0 ? (
           <span className="text-stone-600">

--- a/ui/src/components/SessionPanel.tsx
+++ b/ui/src/components/SessionPanel.tsx
@@ -12,8 +12,7 @@ function formatTokens(count: number): string {
 function formatCost(cost?: string): string {
   if (!cost) return '-';
   const num = parseFloat(cost);
-  if (isNaN(num)) return cost;
-  if (num === 0) return '-';
+  if (isNaN(num) || num === 0) return '-';
   return `$${num.toFixed(4)}`;
 }
 

--- a/ui/src/components/TerminalPanel.tsx
+++ b/ui/src/components/TerminalPanel.tsx
@@ -9,12 +9,13 @@ import '@xterm/xterm/css/xterm.css';
 interface TerminalPanelProps {
   namespace: string;
   agentName: string;
+  defaultMode?: PanelMode;
 }
 
 type PanelMode = 'collapsed' | 'expanded' | 'maximized';
 
-function TerminalPanel({ namespace, agentName }: TerminalPanelProps) {
-  const [mode, setMode] = useState<PanelMode>('collapsed');
+function TerminalPanel({ namespace, agentName, defaultMode = 'collapsed' }: TerminalPanelProps) {
+  const [mode, setMode] = useState<PanelMode>(defaultMode);
   const termRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -201,7 +202,7 @@ function TerminalPanel({ namespace, agentName }: TerminalPanelProps) {
         className={
           isMaximized
             ? 'fixed inset-3 z-50 bg-stone-950 flex flex-col rounded-2xl overflow-hidden shadow-2xl ring-1 ring-white/10'
-            : 'bg-stone-950 rounded-xl overflow-hidden border border-stone-800 animate-fade-in'
+            : 'bg-stone-950 rounded-xl overflow-hidden border border-stone-800 animate-fade-in flex flex-col'
         }
         style={isMaximized ? { animation: 'panel-maximize 0.2s cubic-bezier(0.16, 1, 0.3, 1)' } : undefined}
       >
@@ -252,7 +253,7 @@ function TerminalPanel({ namespace, agentName }: TerminalPanelProps) {
         <div
           ref={termRef}
           className={isMaximized ? 'flex-1 min-h-0' : ''}
-          style={isMaximized ? { height: '100%' } : { height: '70vh' }}
+          style={{ height: isMaximized ? '100%' : 'calc(100vh - 280px)', minHeight: '400px' }}
         />
       </div>
     </>

--- a/ui/src/components/YamlViewer.tsx
+++ b/ui/src/components/YamlViewer.tsx
@@ -9,6 +9,8 @@ interface YamlViewerProps {
   queryKey: string[];
   fetchYaml: () => Promise<string>;
   onSave?: (yaml: string) => Promise<void>;
+  defaultOpen?: boolean;
+  hideToggle?: boolean;
 }
 
 interface YamlError {
@@ -88,8 +90,8 @@ const darkTheme = EditorView.theme({
   },
 });
 
-function YamlViewer({ queryKey, fetchYaml, onSave }: YamlViewerProps) {
-  const [isOpen, setIsOpen] = useState(false);
+function YamlViewer({ queryKey, fetchYaml, onSave, defaultOpen = false, hideToggle = false }: YamlViewerProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const [saving, setSaving] = useState(false);
@@ -163,21 +165,23 @@ function YamlViewer({ queryKey, fetchYaml, onSave }: YamlViewerProps) {
   );
 
   return (
-    <div className="mt-6">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center space-x-2 text-xs font-display font-medium text-stone-400 hover:text-stone-600 uppercase tracking-wider transition-colors"
-      >
-        <svg
-          className={`w-3.5 h-3.5 transform transition-transform ${isOpen ? 'rotate-90' : ''}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
+    <div className={hideToggle ? '' : 'mt-6'}>
+      {!hideToggle && (
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className="flex items-center space-x-2 text-xs font-display font-medium text-stone-400 hover:text-stone-600 uppercase tracking-wider transition-colors"
         >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-        </svg>
-        <span>YAML</span>
-      </button>
+          <svg
+            className={`w-3.5 h-3.5 transform transition-transform ${isOpen ? 'rotate-90' : ''}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+          <span>YAML</span>
+        </button>
+      )}
       {isOpen && (
         <div className="mt-2 bg-stone-800 rounded-xl overflow-hidden border border-stone-700 animate-fade-in">
           <div className="px-4 py-2.5 bg-stone-700/50 flex items-center justify-between border-b border-stone-600/50">
@@ -226,7 +230,7 @@ function YamlViewer({ queryKey, fetchYaml, onSave }: YamlViewerProps) {
                   onChange={setEditValue}
                   extensions={extensions}
                   theme="dark"
-                  height="384px"
+                  height={hideToggle ? 'calc(100vh - 320px)' : '384px'}
                   basicSetup={{
                     lineNumbers: true,
                     foldGutter: true,
@@ -275,8 +279,8 @@ function YamlViewer({ queryKey, fetchYaml, onSave }: YamlViewerProps) {
                 value={yaml || ''}
                 extensions={readOnlyExtensions}
                 theme="dark"
-                height="auto"
-                maxHeight="384px"
+                height={hideToggle ? 'auto' : 'auto'}
+                maxHeight={hideToggle ? 'calc(100vh - 280px)' : '384px'}
                 basicSetup={{
                   lineNumbers: true,
                   foldGutter: true,

--- a/ui/src/pages/AgentDetailPage.tsx
+++ b/ui/src/pages/AgentDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import api, { ShareTokenResponse } from '../api/client';
 import { useToast } from '../contexts/ToastContext';
@@ -11,6 +11,8 @@ import Breadcrumbs from '../components/Breadcrumbs';
 import YamlViewer from '../components/YamlViewer';
 import TerminalPanel from '../components/TerminalPanel';
 import { DetailSkeleton } from '../components/Skeleton';
+
+type TabId = 'overview' | 'terminal' | 'share' | 'yaml';
 
 function SuspendResumeButton({ namespace, name, suspended, onSuccess }: { namespace: string; name: string; suspended: boolean; onSuccess: () => void }) {
   const [loading, setLoading] = useState(false);
@@ -96,6 +98,33 @@ function ServerConnectCommands({ namespace, agentName }: { namespace: string; ag
   );
 }
 
+// Validate a comma-separated list of CIDR/IP entries.
+// Returns null if valid, or an error string if invalid.
+function validateAllowedIPs(input: string): string | null {
+  if (!input.trim()) return null;
+  const entries = input.split(',').map(s => s.trim()).filter(Boolean);
+  for (const entry of entries) {
+    // Match IPv4 with optional CIDR prefix
+    if (!/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(\/\d{1,2})?$/.test(entry)) {
+      return `Invalid format: "${entry}". Expected IPv4 or CIDR (e.g. 10.0.0.0/8)`;
+    }
+    // Validate each octet
+    const ipPart = entry.split('/')[0];
+    const octets = ipPart.split('.').map(Number);
+    if (octets.some(o => o < 0 || o > 255)) {
+      return `Invalid IP: "${entry}". Each octet must be 0-255`;
+    }
+    // Validate CIDR prefix length
+    if (entry.includes('/')) {
+      const prefix = Number(entry.split('/')[1]);
+      if (prefix < 0 || prefix > 32) {
+        return `Invalid CIDR prefix: "${entry}". Must be 0-32`;
+      }
+    }
+  }
+  return null;
+}
+
 function ShareLinkSection({ namespace, name, shareStatus }: {
   namespace: string;
   name: string;
@@ -107,6 +136,7 @@ function ShareLinkSection({ namespace, name, shareStatus }: {
   const [showConfig, setShowConfig] = useState(false);
   const [expiresIn, setExpiresIn] = useState('');
   const [allowedIPs, setAllowedIPs] = useState(shareStatus?.allowedIPs?.join(', ') || '');
+  const [ipError, setIpError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
   const enabled = shareStatus?.enabled || false;
@@ -123,6 +153,10 @@ function ShareLinkSection({ namespace, name, shareStatus }: {
   }, [queryClient, namespace, name]);
 
   const handleToggle = async () => {
+    if (!enabled) {
+      const err = validateAllowedIPs(allowedIPs);
+      if (err) { setIpError(err); return; }
+    }
     setLoading(true);
     try {
       if (enabled) {
@@ -144,6 +178,8 @@ function ShareLinkSection({ namespace, name, shareStatus }: {
   };
 
   const handleUpdateConfig = async () => {
+    const err = validateAllowedIPs(allowedIPs);
+    if (err) { setIpError(err); return; }
     setLoading(true);
     try {
       await api.updateAgentShare(namespace, name, {
@@ -157,6 +193,11 @@ function ShareLinkSection({ namespace, name, shareStatus }: {
       addToast(`Failed: ${(err as Error).message}`, 'error');
       setLoading(false);
     }
+  };
+
+  const handleAllowedIPsChange = (value: string) => {
+    setAllowedIPs(value);
+    if (ipError) setIpError(null); // Clear error on edit
   };
 
   const shareUrl = shareToken?.path ? `${window.location.origin}${shareToken.path}` : '';
@@ -207,10 +248,14 @@ function ShareLinkSection({ namespace, name, shareStatus }: {
               <input
                 type="text"
                 value={allowedIPs}
-                onChange={e => setAllowedIPs(e.target.value)}
+                onChange={e => handleAllowedIPsChange(e.target.value)}
+                onBlur={() => { if (allowedIPs.trim()) setIpError(validateAllowedIPs(allowedIPs)); }}
                 placeholder="e.g., 10.0.0.0/8, 192.168.1.0/24"
-                className="mt-0.5 w-full px-2.5 py-1.5 text-xs border border-stone-200 rounded-md bg-white"
+                className={`mt-0.5 w-full px-2.5 py-1.5 text-xs border rounded-md bg-white ${
+                  ipError ? 'border-red-300 focus:ring-red-500' : 'border-stone-200'
+                }`}
               />
+              {ipError && <p className="mt-1 text-[11px] text-red-500">{ipError}</p>}
             </div>
           </div>
         </div>
@@ -222,11 +267,19 @@ function ShareLinkSection({ namespace, name, shareStatus }: {
               <span className="text-xs font-medium text-emerald-800">
                 {shareToken?.active ? 'Active' : 'Inactive'}
               </span>
-              {shareStatus?.expiresAt && (
-                <span className="text-[10px] text-stone-500">
-                  Expires: {new Date(shareStatus.expiresAt).toLocaleString()}
-                </span>
-              )}
+            </div>
+            <div className="flex items-center gap-3 text-[11px] text-stone-500 mb-2">
+              <span>
+                {shareStatus?.expiresAt
+                  ? `Expires: ${new Date(shareStatus.expiresAt).toLocaleString()}`
+                  : 'No expiration'}
+              </span>
+              <span className="text-stone-300">|</span>
+              <span>
+                {shareStatus?.allowedIPs && shareStatus.allowedIPs.length > 0
+                  ? `IPs: ${shareStatus.allowedIPs.join(', ')}`
+                  : 'All IPs allowed'}
+              </span>
             </div>
             {shareUrl && (
               <div className="flex items-center gap-2 bg-stone-900 rounded-lg px-3 py-2 border border-stone-700">
@@ -291,14 +344,18 @@ function ShareLinkSection({ namespace, name, shareStatus }: {
                 <input
                   type="text"
                   value={allowedIPs}
-                  onChange={e => setAllowedIPs(e.target.value)}
+                  onChange={e => handleAllowedIPsChange(e.target.value)}
+                  onBlur={() => { if (allowedIPs.trim()) setIpError(validateAllowedIPs(allowedIPs)); }}
                   placeholder="e.g., 10.0.0.0/8 (empty = all IPs)"
-                  className="mt-0.5 w-full px-2.5 py-1.5 text-xs border border-stone-200 rounded-md bg-white"
+                  className={`mt-0.5 w-full px-2.5 py-1.5 text-xs border rounded-md bg-white ${
+                    ipError ? 'border-red-300 focus:ring-red-500' : 'border-stone-200'
+                  }`}
                 />
+                {ipError && <p className="mt-1 text-[11px] text-red-500">{ipError}</p>}
               </div>
               <button
                 onClick={handleUpdateConfig}
-                disabled={loading}
+                disabled={loading || !!ipError}
                 className="px-3 py-1.5 text-xs font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50"
               >
                 {loading ? 'Saving...' : 'Save Changes'}
@@ -311,12 +368,69 @@ function ShareLinkSection({ namespace, name, shareStatus }: {
   );
 }
 
+const TABS: { id: TabId; label: string; icon: React.ReactNode }[] = [
+  {
+    id: 'overview',
+    label: 'Overview',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="3" width="7" height="7" rx="1" />
+        <rect x="14" y="3" width="7" height="7" rx="1" />
+        <rect x="3" y="14" width="7" height="7" rx="1" />
+        <rect x="14" y="14" width="7" height="7" rx="1" />
+      </svg>
+    ),
+  },
+  {
+    id: 'terminal',
+    label: 'Terminal',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="4 17 10 11 4 5" />
+        <line x1="12" y1="19" x2="20" y2="19" />
+      </svg>
+    ),
+  },
+  {
+    id: 'share',
+    label: 'Share',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      </svg>
+    ),
+  },
+  {
+    id: 'yaml',
+    label: 'YAML',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+    ),
+  },
+];
+
 function AgentDetailPage() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const { addToast } = useToast();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleting, setDeleting] = useState(false);
+
+  // Determine initial tab from URL hash
+  const hashTab = location.hash.replace('#', '') as TabId;
+  const initialTab: TabId = ['overview', 'terminal', 'share', 'yaml'].includes(hashTab) ? hashTab : 'overview';
+  const [activeTab, setActiveTab] = useState<TabId>(initialTab);
+
+  const handleTabChange = (tab: TabId) => {
+    setActiveTab(tab);
+    // Update URL hash without creating a new history entry
+    window.history.replaceState(null, '', `${location.pathname}#${tab}`);
+  };
 
   const { data: agent, isLoading, error, refetch } = useQuery({
     queryKey: ['agent', namespace, name],
@@ -357,6 +471,14 @@ function AgentDetailPage() {
     );
   }
 
+  const terminalReady = !!(agent.serverStatus && agent.serverStatus.ready);
+  const hasCredentials = agent.credentials && agent.credentials.length > 0;
+  const hasSkills = agent.skills && agent.skills.length > 0;
+  const hasPlugins = agent.plugins && agent.plugins.length > 0;
+  const hasConfig = agent.config && Object.keys(agent.config).length > 0;
+  const hasContexts = agent.contexts && agent.contexts.length > 0;
+
+
   return (
     <div className="animate-fade-in">
       <Breadcrumbs items={[
@@ -366,6 +488,7 @@ function AgentDetailPage() {
       ]} />
 
       <div className="bg-white rounded-xl border-0 overflow-hidden shadow-card">
+        {/* Header */}
         <div className="px-6 py-5 border-b border-stone-100">
           <div className="flex items-start justify-between gap-4">
             <div className="min-w-0 flex-1">
@@ -409,413 +532,455 @@ function AgentDetailPage() {
           </div>
         </div>
 
-        <div className="px-6 py-5 space-y-6">
-          {/* Labels */}
-          {agent.labels && Object.keys(agent.labels).length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Labels</h3>
-              <Labels labels={agent.labels} />
-            </div>
-          )}
+        {/* Tab Bar */}
+        <div className="px-6 border-b border-stone-100 bg-stone-50/50">
+          <nav className="flex space-x-1 -mb-px" aria-label="Tabs">
+            {TABS.map((tab) => {
+              const isActive = activeTab === tab.id;
+              // Hide terminal tab if server not ready
+              if (tab.id === 'terminal' && !terminalReady) return null;
+              // Hide share tab if server not available
+              if (tab.id === 'share' && !agent.serverStatus) return null;
+              return (
+                <button
+                  key={tab.id}
+                  onClick={() => handleTabChange(tab.id)}
+                  className={`flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium border-b-2 transition-colors ${
+                    isActive
+                      ? 'border-primary-600 text-primary-700'
+                      : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
+                  }`}
+                >
+                  <span className={isActive ? 'text-primary-600' : 'text-stone-400'}>{tab.icon}</span>
+                  {tab.label}
+                  {tab.id === 'share' && agent.share?.enabled && (
+                    <span className={`w-1.5 h-1.5 rounded-full ${
+                      isActive ? 'bg-emerald-500' : 'bg-emerald-400'
+                    }`} />
+                  )}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
 
-          {/* Template Reference */}
-          {agent.templateRef && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Template</h3>
-              <Link
-                to={`/templates/${agent.namespace}/${agent.templateRef.name}`}
-                className="inline-flex items-center gap-2 bg-teal-50 rounded-lg px-4 py-2.5 border border-teal-200 hover:border-teal-300 transition-colors group"
-              >
-                <svg className="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="3" y="3" width="7" height="7" rx="1" />
-                  <rect x="14" y="3" width="7" height="7" rx="1" />
-                  <rect x="3" y="14" width="7" height="7" rx="1" />
-                  <rect x="14" y="14" width="7" height="7" rx="1" />
-                </svg>
-                <span className="text-sm font-medium text-teal-700 group-hover:text-teal-800">{agent.templateRef.name}</span>
-                <svg className="w-3.5 h-3.5 text-teal-400 group-hover:text-teal-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </Link>
-            </div>
-          )}
-
-          {/* Images */}
-          {(agent.executorImage || agent.agentImage) && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Images</h3>
-              <div className="grid grid-cols-2 gap-x-6 gap-y-4">
-                {agent.executorImage && (
-                  <div>
-                    <dt className="text-xs text-stone-400">Executor Image</dt>
-                    <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
-                      {agent.executorImage}
-                    </dd>
-                  </div>
-                )}
-                {agent.agentImage && (
-                  <div>
-                    <dt className="text-xs text-stone-400">Agent Image</dt>
-                    <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
-                      {agent.agentImage}
-                    </dd>
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Runtime */}
-          {(agent.workspaceDir || agent.serviceAccountName) && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Runtime</h3>
-              <div className="grid grid-cols-2 gap-x-6 gap-y-4">
-                {agent.workspaceDir && (
-                  <div>
-                    <dt className="text-xs text-stone-400">Workspace Directory</dt>
-                    <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.workspaceDir}</dd>
-                  </div>
-                )}
-                {agent.serviceAccountName && (
-                  <div>
-                    <dt className="text-xs text-stone-400">Service Account</dt>
-                    <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serviceAccountName}</dd>
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Task Management */}
-          {(agent.maxConcurrentTasks || agent.quota || agent.standby) && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Task Management</h3>
-              <div className="grid grid-cols-2 gap-x-6 gap-y-4">
-                {agent.maxConcurrentTasks && (
-                  <div>
-                    <dt className="text-xs text-stone-400">Max Concurrent Tasks</dt>
-                    <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.maxConcurrentTasks}</dd>
-                  </div>
-                )}
-                {agent.quota && (
-                  <div>
-                    <dt className="text-xs text-stone-400">Quota</dt>
-                    <dd className="mt-1 text-sm text-stone-700">
-                      Max <span className="font-mono font-medium text-stone-800">{agent.quota.maxTaskStarts}</span> starts per{' '}
-                      <span className="font-mono font-medium text-stone-800">{agent.quota.windowSeconds}</span>s
-                    </dd>
-                  </div>
-                )}
-                {agent.standby && (
-                  <div>
-                    <dt className="text-xs text-stone-400">Standby</dt>
-                    <dd className="mt-1 text-sm text-stone-700">
-                      Auto-suspend after <span className="font-mono font-medium text-stone-800">{agent.standby.idleTimeout}</span> idle
-                    </dd>
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Server Status */}
-          <div>
-            <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Server Status</h3>
-            {agent.serverStatus ? (
-              <div className="grid grid-cols-2 gap-x-6 gap-y-4">
-                <div>
-                  <dt className="text-xs text-stone-400">Deployment</dt>
-                  <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serverStatus.deploymentName}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-stone-400">Service</dt>
-                  <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serverStatus.serviceName}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-stone-400">URL</dt>
-                  <dd className="mt-1 flex items-center gap-1.5">
-                    <span className="text-sm text-stone-700 font-mono break-all">{agent.serverStatus.url}</span>
-                    <CopyButton text={agent.serverStatus.url || ''} />
-                  </dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-stone-400">Status</dt>
-                  <dd className="mt-1 text-sm font-mono">
-                    {agent.serverStatus.suspended ? (
-                      <span className="text-amber-600">Suspended</span>
-                    ) : agent.serverStatus.ready ? (
-                      <span className="text-emerald-600">Ready</span>
-                    ) : (
-                      <span className="text-stone-500">Not Ready</span>
-                    )}
-                  </dd>
-                </div>
-              </div>
-            ) : (
-              <div className="bg-amber-50 rounded-lg p-4 border border-amber-200">
-                <div className="flex items-center gap-2">
-                  <span className="w-2 h-2 rounded-full bg-amber-500 animate-pulse" />
-                  <p className="text-sm text-amber-700 font-medium">Server not ready</p>
-                </div>
-                <p className="text-xs text-amber-600 mt-1">
-                  The server deployment has not been created yet or is still starting up. Check controller logs for errors.
-                </p>
+        {/* Tab Content */}
+        {activeTab === 'overview' && (
+          <div className="px-6 py-5 space-y-6">
+            {/* Labels */}
+            {agent.labels && Object.keys(agent.labels).length > 0 && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Labels</h3>
+                <Labels labels={agent.labels} />
               </div>
             )}
-          </div>
 
-          {/* Git Sync Status */}
-          {agent.serverStatus?.gitSyncStatuses && agent.serverStatus.gitSyncStatuses.length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Git Sync</h3>
-              <div className="space-y-2">
-                {agent.serverStatus.gitSyncStatuses.map((gs, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800">{gs.name}</span>
-                      {gs.commitHash && (
-                        <span className="text-[11px] font-mono text-stone-500 bg-stone-100 px-2 py-0.5 rounded">
-                          {gs.commitHash.substring(0, 12)}
-                        </span>
-                      )}
-                    </div>
-                    {gs.lastSynced && (
-                      <p className="text-xs text-stone-400 mt-1">
-                        Last synced: {new Date(gs.lastSynced).toLocaleString()}
-                      </p>
-                    )}
-                  </div>
-                ))}
+            {/* Template Reference */}
+            {agent.templateRef && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Template</h3>
+                <Link
+                  to={`/templates/${agent.namespace}/${agent.templateRef.name}`}
+                  className="inline-flex items-center gap-2 bg-teal-50 rounded-lg px-4 py-2.5 border border-teal-200 hover:border-teal-300 transition-colors group"
+                >
+                  <svg className="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="3" y="3" width="7" height="7" rx="1" />
+                    <rect x="14" y="3" width="7" height="7" rx="1" />
+                    <rect x="3" y="14" width="7" height="7" rx="1" />
+                    <rect x="14" y="14" width="7" height="7" rx="1" />
+                  </svg>
+                  <span className="text-sm font-medium text-teal-700 group-hover:text-teal-800">{agent.templateRef.name}</span>
+                  <svg className="w-3.5 h-3.5 text-teal-400 group-hover:text-teal-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </Link>
               </div>
-              {agent.conditions?.some(c => c.type === 'GitSyncPending' && c.status === 'True') && (
-                <div className="mt-2 bg-amber-50 rounded-lg p-3 border border-amber-200">
+            )}
+
+            {/* Images */}
+            {(agent.executorImage || agent.agentImage) && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Images</h3>
+                <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+                  {agent.executorImage && (
+                    <div>
+                      <dt className="text-xs text-stone-400">Executor Image</dt>
+                      <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
+                        {agent.executorImage}
+                      </dd>
+                    </div>
+                  )}
+                  {agent.agentImage && (
+                    <div>
+                      <dt className="text-xs text-stone-400">Agent Image</dt>
+                      <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
+                        {agent.agentImage}
+                      </dd>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Runtime */}
+            {(agent.workspaceDir || agent.serviceAccountName) && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Runtime</h3>
+                <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+                  {agent.workspaceDir && (
+                    <div>
+                      <dt className="text-xs text-stone-400">Workspace Directory</dt>
+                      <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.workspaceDir}</dd>
+                    </div>
+                  )}
+                  {agent.serviceAccountName && (
+                    <div>
+                      <dt className="text-xs text-stone-400">Service Account</dt>
+                      <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serviceAccountName}</dd>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Task Management */}
+            {(agent.maxConcurrentTasks || agent.quota || agent.standby) && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Task Management</h3>
+                <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+                  {agent.maxConcurrentTasks && (
+                    <div>
+                      <dt className="text-xs text-stone-400">Max Concurrent Tasks</dt>
+                      <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.maxConcurrentTasks}</dd>
+                    </div>
+                  )}
+                  {agent.quota && (
+                    <div>
+                      <dt className="text-xs text-stone-400">Quota</dt>
+                      <dd className="mt-1 text-sm text-stone-700">
+                        Max <span className="font-mono font-medium text-stone-800">{agent.quota.maxTaskStarts}</span> starts per{' '}
+                        <span className="font-mono font-medium text-stone-800">{agent.quota.windowSeconds}</span>s
+                      </dd>
+                    </div>
+                  )}
+                  {agent.standby && (
+                    <div>
+                      <dt className="text-xs text-stone-400">Standby</dt>
+                      <dd className="mt-1 text-sm text-stone-700">
+                        Auto-suspend after <span className="font-mono font-medium text-stone-800">{agent.standby.idleTimeout}</span> idle
+                      </dd>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Server Status */}
+            <div>
+              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Server Status</h3>
+              {agent.serverStatus ? (
+                <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+                  <div>
+                    <dt className="text-xs text-stone-400">Deployment</dt>
+                    <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serverStatus.deploymentName}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-stone-400">Service</dt>
+                    <dd className="mt-1 text-sm text-stone-700 font-mono">{agent.serverStatus.serviceName}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-stone-400">URL</dt>
+                    <dd className="mt-1 flex items-center gap-1.5">
+                      <span className="text-sm text-stone-700 font-mono break-all">{agent.serverStatus.url}</span>
+                      <CopyButton text={agent.serverStatus.url || ''} />
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-stone-400">Status</dt>
+                    <dd className="mt-1 text-sm font-mono">
+                      {agent.serverStatus.suspended ? (
+                        <span className="text-amber-600">Suspended</span>
+                      ) : agent.serverStatus.ready ? (
+                        <span className="text-emerald-600">Ready</span>
+                      ) : (
+                        <span className="text-stone-500">Not Ready</span>
+                      )}
+                    </dd>
+                  </div>
+                </div>
+              ) : (
+                <div className="bg-amber-50 rounded-lg p-4 border border-amber-200">
                   <div className="flex items-center gap-2">
                     <span className="w-2 h-2 rounded-full bg-amber-500 animate-pulse" />
-                    <p className="text-sm text-amber-700 font-medium">Rollout pending</p>
+                    <p className="text-sm text-amber-700 font-medium">Server not ready</p>
                   </div>
                   <p className="text-xs text-amber-600 mt-1">
-                    {agent.conditions.find(c => c.type === 'GitSyncPending')?.message}
+                    The server deployment has not been created yet or is still starting up. Check controller logs for errors.
                   </p>
                 </div>
               )}
             </div>
-          )}
 
-          {/* Terminal Panel (ready) */}
-          {agent.serverStatus && agent.serverStatus.ready && (
-            <TerminalPanel namespace={agent.namespace} agentName={agent.name} />
-          )}
+            {/* Git Sync Status */}
+            {agent.serverStatus?.gitSyncStatuses && agent.serverStatus.gitSyncStatuses.length > 0 && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Git Sync</h3>
+                <div className="space-y-2">
+                  {agent.serverStatus.gitSyncStatuses.map((gs, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800">{gs.name}</span>
+                        {gs.commitHash && (
+                          <span className="text-[11px] font-mono text-stone-500 bg-stone-100 px-2 py-0.5 rounded">
+                            {gs.commitHash.substring(0, 12)}
+                          </span>
+                        )}
+                      </div>
+                      {gs.lastSynced && (
+                        <p className="text-xs text-stone-400 mt-1">
+                          Last synced: {new Date(gs.lastSynced).toLocaleString()}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+                {agent.conditions?.some(c => c.type === 'GitSyncPending' && c.status === 'True') && (
+                  <div className="mt-2 bg-amber-50 rounded-lg p-3 border border-amber-200">
+                    <div className="flex items-center gap-2">
+                      <span className="w-2 h-2 rounded-full bg-amber-500 animate-pulse" />
+                      <p className="text-sm text-amber-700 font-medium">Rollout pending</p>
+                    </div>
+                    <p className="text-xs text-amber-600 mt-1">
+                      {agent.conditions.find(c => c.type === 'GitSyncPending')?.message}
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
 
-          {/* Quick Connect */}
-          {agent.serverStatus && (
-            <ServerConnectCommands
-              namespace={agent.namespace}
-              agentName={agent.name}
-            />
-          )}
+            {/* Quick Connect */}
+            {agent.serverStatus && (
+              <ServerConnectCommands
+                namespace={agent.namespace}
+                agentName={agent.name}
+              />
+            )}
 
-          {/* Share Link */}
-          {agent.serverStatus && (
+            {/* Conditions */}
+            {agent.conditions && agent.conditions.length > 0 && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Conditions</h3>
+                <div className="space-y-2">
+                  {agent.conditions.map((condition, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800">{condition.type}</span>
+                        <span className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
+                          condition.status === 'True'
+                            ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
+                            : 'bg-stone-50 text-stone-500 border-stone-200'
+                        }`}>
+                          {condition.status}
+                        </span>
+                      </div>
+                      {condition.reason && (
+                        <p className="text-xs text-stone-500 mt-1">Reason: {condition.reason}</p>
+                      )}
+                      {condition.message && (
+                        <p className="text-xs text-stone-400 mt-1">{condition.message}</p>
+                      )}
+                    </div>
+                   ))}
+                </div>
+              </div>
+            )}
+
+            {/* Credentials */}
+            {hasCredentials && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
+                  Credentials ({agent.credentials!.length})
+                </h3>
+                <div className="space-y-2">
+                  {agent.credentials!.map((cred, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800">{cred.name}</span>
+                        <span className="text-xs text-stone-400 font-mono">{cred.secretRef}</span>
+                      </div>
+                      {(cred.env || cred.mountPath) && (
+                        <div className="mt-1 text-xs text-stone-500 space-x-3">
+                          {cred.env && <span>ENV: <span className="font-mono">{cred.env}</span></span>}
+                          {cred.mountPath && <span>Mount: <span className="font-mono">{cred.mountPath}</span></span>}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Skills */}
+            {hasSkills && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
+                  Skills ({agent.skills!.length})
+                </h3>
+                <div className="space-y-2">
+                  {agent.skills!.map((skill, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800">
+                          {skill.name}
+                        </span>
+                        <span className="text-[11px] px-2 py-0.5 rounded-md bg-violet-50 text-violet-600 border border-violet-200 font-medium">
+                          Git
+                        </span>
+                      </div>
+                      {skill.git && (
+                        <p className="mt-1 text-[11px] text-stone-400 font-mono truncate">
+                          {skill.git.repository}
+                          {skill.git.ref && skill.git.ref !== 'HEAD' ? `@${skill.git.ref}` : ''}
+                          {skill.git.path ? ` / ${skill.git.path}` : ''}
+                        </p>
+                      )}
+                      {skill.git?.names && skill.git.names.length > 0 && (
+                        <div className="mt-1.5 flex flex-wrap gap-1">
+                          {skill.git.names.map((sname, i) => (
+                            <span key={i} className="text-[10px] px-1.5 py-0.5 rounded bg-violet-50 text-violet-500 border border-violet-100">
+                              {sname}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Plugins */}
+            {hasPlugins && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
+                  Plugins ({agent.plugins!.length})
+                </h3>
+                <div className="space-y-2">
+                  {agent.plugins!.map((plugin, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800 font-mono">
+                          {plugin.name}
+                        </span>
+                        {plugin.target && (
+                          <span className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
+                            plugin.target === 'tui'
+                              ? 'bg-amber-50 text-amber-600 border-amber-200'
+                              : 'bg-teal-50 text-teal-600 border-teal-200'
+                          }`}>
+                            {plugin.target}
+                          </span>
+                        )}
+                      </div>
+                      {plugin.options && Object.keys(plugin.options).length > 0 && (
+                        <pre className="mt-2 text-[11px] text-stone-500 font-mono bg-stone-100 rounded p-2 overflow-x-auto">
+                          {JSON.stringify(plugin.options, null, 2)}
+                        </pre>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* OpenCode Config */}
+            {hasConfig && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
+                  OpenCode Config
+                </h3>
+                <pre className="text-xs text-stone-600 font-mono bg-stone-50 rounded-lg p-4 border border-stone-100 overflow-x-auto">
+                  {JSON.stringify(agent.config, null, 2)}
+                </pre>
+              </div>
+            )}
+
+            {/* Contexts */}
+            {hasContexts && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
+                  Contexts ({agent.contexts!.length})
+                </h3>
+                <div className="space-y-2">
+                  {agent.contexts!.map((ctx, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800">
+                          {ctx.name || `Context ${idx + 1}`}
+                        </span>
+                        <span className="text-[11px] px-2 py-0.5 rounded-md bg-sky-50 text-sky-600 border border-sky-200 font-medium">
+                          {ctx.type}
+                        </span>
+                      </div>
+                      {ctx.description && (
+                        <p className="mt-1 text-xs text-stone-500">{ctx.description}</p>
+                      )}
+                      {ctx.mountPath && (
+                        <p className="mt-1 text-[11px] text-stone-400 font-mono">
+                          mount: {ctx.mountPath}
+                        </p>
+                      )}
+                      {ctx.sync && ctx.sync.enabled && (
+                        <div className="mt-1.5 flex items-center gap-2">
+                          <span className="text-[11px] px-1.5 py-0.5 rounded bg-emerald-50 text-emerald-600 border border-emerald-200 font-medium">
+                            sync: {ctx.sync.policy || 'HotReload'}
+                          </span>
+                          {ctx.sync.interval && (
+                            <span className="text-[11px] text-stone-400">
+                              every {ctx.sync.interval}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'terminal' && terminalReady && (
+          <div className="p-4">
+            <TerminalPanel namespace={agent.namespace} agentName={agent.name} defaultMode="expanded" />
+          </div>
+        )}
+
+        {activeTab === 'share' && agent.serverStatus && (
+          <div className="px-6 py-5">
             <ShareLinkSection
               namespace={agent.namespace}
               name={agent.name}
               shareStatus={agent.share}
             />
-          )}
+          </div>
+        )}
 
-          {/* Conditions */}
-          {agent.conditions && agent.conditions.length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Conditions</h3>
-              <div className="space-y-2">
-                {agent.conditions.map((condition, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800">{condition.type}</span>
-                      <span className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
-                        condition.status === 'True'
-                          ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
-                          : 'bg-stone-50 text-stone-500 border-stone-200'
-                      }`}>
-                        {condition.status}
-                      </span>
-                    </div>
-                    {condition.reason && (
-                      <p className="text-xs text-stone-500 mt-1">Reason: {condition.reason}</p>
-                    )}
-                    {condition.message && (
-                      <p className="text-xs text-stone-400 mt-1">{condition.message}</p>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Credentials */}
-          {agent.credentials && agent.credentials.length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
-                Credentials ({agent.credentials.length})
-              </h3>
-              <div className="space-y-2">
-                {agent.credentials.map((cred, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800">{cred.name}</span>
-                      <span className="text-xs text-stone-400 font-mono">{cred.secretRef}</span>
-                    </div>
-                    {(cred.env || cred.mountPath) && (
-                      <div className="mt-1 text-xs text-stone-500 space-x-3">
-                        {cred.env && <span>ENV: <span className="font-mono">{cred.env}</span></span>}
-                        {cred.mountPath && <span>Mount: <span className="font-mono">{cred.mountPath}</span></span>}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Skills */}
-          {agent.skills && agent.skills.length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
-                Skills ({agent.skills.length})
-              </h3>
-              <div className="space-y-2">
-                {agent.skills.map((skill, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800">
-                        {skill.name}
-                      </span>
-                      <span className="text-[11px] px-2 py-0.5 rounded-md bg-violet-50 text-violet-600 border border-violet-200 font-medium">
-                        Git
-                      </span>
-                    </div>
-                    {skill.git && (
-                      <p className="mt-1 text-[11px] text-stone-400 font-mono truncate">
-                        {skill.git.repository}
-                        {skill.git.ref && skill.git.ref !== 'HEAD' ? `@${skill.git.ref}` : ''}
-                        {skill.git.path ? ` / ${skill.git.path}` : ''}
-                      </p>
-                    )}
-                    {skill.git?.names && skill.git.names.length > 0 && (
-                      <div className="mt-1.5 flex flex-wrap gap-1">
-                        {skill.git.names.map((name, i) => (
-                          <span key={i} className="text-[10px] px-1.5 py-0.5 rounded bg-violet-50 text-violet-500 border border-violet-100">
-                            {name}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Plugins */}
-          {agent.plugins && agent.plugins.length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
-                Plugins ({agent.plugins.length})
-              </h3>
-              <div className="space-y-2">
-                {agent.plugins.map((plugin, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800 font-mono">
-                        {plugin.name}
-                      </span>
-                      {plugin.target && (
-                        <span className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
-                          plugin.target === 'tui'
-                            ? 'bg-amber-50 text-amber-600 border-amber-200'
-                            : 'bg-teal-50 text-teal-600 border-teal-200'
-                        }`}>
-                          {plugin.target}
-                        </span>
-                      )}
-                    </div>
-                    {plugin.options && Object.keys(plugin.options).length > 0 && (
-                      <pre className="mt-2 text-[11px] text-stone-500 font-mono bg-stone-100 rounded p-2 overflow-x-auto">
-                        {JSON.stringify(plugin.options, null, 2)}
-                      </pre>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* OpenCode Config */}
-          {agent.config && Object.keys(agent.config).length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
-                OpenCode Config
-              </h3>
-              <pre className="text-xs text-stone-600 font-mono bg-stone-50 rounded-lg p-4 border border-stone-100 overflow-x-auto">
-                {JSON.stringify(agent.config, null, 2)}
-              </pre>
-            </div>
-          )}
-
-          {/* Contexts */}
-          {agent.contexts && agent.contexts.length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
-                Contexts ({agent.contexts.length})
-              </h3>
-              <div className="space-y-2">
-                {agent.contexts.map((ctx, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800">
-                        {ctx.name || `Context ${idx + 1}`}
-                      </span>
-                      <span className="text-[11px] px-2 py-0.5 rounded-md bg-sky-50 text-sky-600 border border-sky-200 font-medium">
-                        {ctx.type}
-                      </span>
-                    </div>
-                    {ctx.description && (
-                      <p className="mt-1 text-xs text-stone-500">{ctx.description}</p>
-                    )}
-                    {ctx.mountPath && (
-                      <p className="mt-1 text-[11px] text-stone-400 font-mono">
-                        mount: {ctx.mountPath}
-                      </p>
-                    )}
-                    {ctx.sync && ctx.sync.enabled && (
-                      <div className="mt-1.5 flex items-center gap-2">
-                        <span className="text-[11px] px-1.5 py-0.5 rounded bg-emerald-50 text-emerald-600 border border-emerald-200 font-medium">
-                          sync: {ctx.sync.policy || 'HotReload'}
-                        </span>
-                        {ctx.sync.interval && (
-                          <span className="text-[11px] text-stone-400">
-                            every {ctx.sync.interval}
-                          </span>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-        </div>
+        {activeTab === 'yaml' && (
+          <div className="p-4">
+            <YamlViewer
+              queryKey={['agent', namespace!, name!]}
+              fetchYaml={() => api.getAgentYaml(namespace!, name!)}
+              onSave={async (yaml) => {
+                await api.updateAgentYaml(namespace!, name!, yaml);
+                refetch();
+              }}
+              defaultOpen
+              hideToggle
+            />
+          </div>
+        )}
       </div>
-
-      <YamlViewer
-        queryKey={['agent', namespace!, name!]}
-        fetchYaml={() => api.getAgentYaml(namespace!, name!)}
-        onSave={async (yaml) => {
-          await api.updateAgentYaml(namespace!, name!, yaml);
-          refetch();
-        }}
-      />
 
       <ConfirmDialog
         open={showDeleteDialog}

--- a/ui/src/pages/AgentTemplateDetailPage.tsx
+++ b/ui/src/pages/AgentTemplateDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import api from '../api/client';
 import { useToast } from '../contexts/ToastContext';
@@ -10,11 +10,60 @@ import Breadcrumbs from '../components/Breadcrumbs';
 import YamlViewer from '../components/YamlViewer';
 import { DetailSkeleton } from '../components/Skeleton';
 
+type TemplateTabId = 'overview' | 'agents' | 'yaml';
+
+const TEMPLATE_TABS: { id: TemplateTabId; label: string; icon: React.ReactNode }[] = [
+  {
+    id: 'overview',
+    label: 'Overview',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="3" width="7" height="7" rx="1" />
+        <rect x="14" y="3" width="7" height="7" rx="1" />
+        <rect x="3" y="14" width="7" height="7" rx="1" />
+        <rect x="14" y="14" width="7" height="7" rx="1" />
+      </svg>
+    ),
+  },
+  {
+    id: 'agents',
+    label: 'Agents',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="5" y="11" width="14" height="10" rx="2" />
+        <circle cx="9" cy="16" r="1" />
+        <circle cx="15" cy="16" r="1" />
+        <path d="M9 7L9 4M15 7L15 4M12 7L12 2" />
+      </svg>
+    ),
+  },
+  {
+    id: 'yaml',
+    label: 'YAML',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+    ),
+  },
+];
+
 function AgentTemplateDetailPage() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const { addToast } = useToast();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  const hashTab = location.hash.replace('#', '') as TemplateTabId;
+  const initialTab: TemplateTabId = ['overview', 'agents', 'yaml'].includes(hashTab) ? hashTab : 'overview';
+  const [activeTab, setActiveTab] = useState<TemplateTabId>(initialTab);
+
+  const handleTabChange = (tab: TemplateTabId) => {
+    setActiveTab(tab);
+    window.history.replaceState(null, '', `${location.pathname}#${tab}`);
+  };
 
   const { data: tmpl, isLoading, error, refetch } = useQuery({
     queryKey: ['agent-template', namespace, name],
@@ -73,6 +122,7 @@ function AgentTemplateDetailPage() {
       ]} />
 
       <div className="bg-white rounded-xl border-0 overflow-hidden shadow-card">
+        {/* Header */}
         <div className="px-6 py-5 border-b border-stone-100">
           <div className="flex items-center justify-between">
             <div>
@@ -99,57 +149,246 @@ function AgentTemplateDetailPage() {
           </div>
         </div>
 
-        <div className="px-6 py-5 space-y-6">
-          {/* Labels */}
-          {tmpl.labels && Object.keys(tmpl.labels).length > 0 && (
+        {/* Tab Bar */}
+        <div className="px-6 border-b border-stone-100 bg-stone-50/50">
+          <nav className="flex space-x-1 -mb-px" aria-label="Tabs">
+            {TEMPLATE_TABS.map((tab) => {
+              const isActive = activeTab === tab.id;
+              return (
+                <button
+                  key={tab.id}
+                  onClick={() => handleTabChange(tab.id)}
+                  className={`flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium border-b-2 transition-colors ${
+                    isActive
+                      ? 'border-primary-600 text-primary-700'
+                      : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
+                  }`}
+                >
+                  <span className={isActive ? 'text-primary-600' : 'text-stone-400'}>{tab.icon}</span>
+                  {tab.label}
+                  {tab.id === 'agents' && referencingAgents.length > 0 && (
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${
+                      isActive ? 'bg-primary-100 text-primary-600' : 'bg-stone-200 text-stone-500'
+                    }`}>
+                      {referencingAgents.length}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+
+        {/* Overview Tab */}
+        {activeTab === 'overview' && (
+          <div className="px-6 py-5 space-y-6">
+            {/* Labels */}
+            {tmpl.labels && Object.keys(tmpl.labels).length > 0 && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Labels</h3>
+                <Labels labels={tmpl.labels} />
+              </div>
+            )}
+
+            {/* Configuration */}
             <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Labels</h3>
-              <Labels labels={tmpl.labels} />
+              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Configuration</h3>
+              <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+                {tmpl.executorImage && (
+                  <div>
+                    <dt className="text-xs text-stone-400">Executor Image</dt>
+                    <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
+                      {tmpl.executorImage}
+                    </dd>
+                  </div>
+                )}
+                {tmpl.agentImage && (
+                  <div>
+                    <dt className="text-xs text-stone-400">Agent Image</dt>
+                    <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
+                      {tmpl.agentImage}
+                    </dd>
+                  </div>
+                )}
+                {tmpl.workspaceDir && (
+                  <div>
+                    <dt className="text-xs text-stone-400">Workspace Directory</dt>
+                    <dd className="mt-1 text-sm text-stone-700 font-mono">{tmpl.workspaceDir}</dd>
+                  </div>
+                )}
+                {tmpl.serviceAccountName && (
+                  <div>
+                    <dt className="text-xs text-stone-400">Service Account</dt>
+                    <dd className="mt-1 text-sm text-stone-700 font-mono">{tmpl.serviceAccountName}</dd>
+                  </div>
+                )}
+              </div>
             </div>
-          )}
 
-          {/* Configuration */}
-          <div>
-            <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Configuration</h3>
-            <div className="grid grid-cols-2 gap-x-6 gap-y-4">
-              {tmpl.executorImage && (
-                <div>
-                  <dt className="text-xs text-stone-400">Executor Image</dt>
-                  <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
-                    {tmpl.executorImage}
-                  </dd>
+            {/* Conditions */}
+            {tmpl.conditions && tmpl.conditions.length > 0 && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Conditions</h3>
+                <div className="space-y-2">
+                  {tmpl.conditions.map((condition, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800">{condition.type}</span>
+                        <span className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
+                          condition.status === 'True'
+                            ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
+                            : 'bg-stone-50 text-stone-500 border-stone-200'
+                        }`}>
+                          {condition.status}
+                        </span>
+                      </div>
+                      {condition.reason && (
+                        <p className="text-xs text-stone-500 mt-1">Reason: {condition.reason}</p>
+                      )}
+                      {condition.message && (
+                        <p className="text-xs text-stone-400 mt-1">{condition.message}</p>
+                      )}
+                    </div>
+                  ))}
                 </div>
-              )}
-              {tmpl.agentImage && (
-                <div>
-                  <dt className="text-xs text-stone-400">Agent Image</dt>
-                  <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
-                    {tmpl.agentImage}
-                  </dd>
+              </div>
+            )}
+
+            {/* Credentials */}
+            {tmpl.credentials && tmpl.credentials.length > 0 && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
+                  Credentials ({tmpl.credentials.length})
+                </h3>
+                <div className="space-y-2">
+                  {tmpl.credentials.map((cred, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800">{cred.name}</span>
+                        <span className="text-xs text-stone-400 font-mono">{cred.secretRef}</span>
+                      </div>
+                      {(cred.env || cred.mountPath) && (
+                        <div className="mt-1 text-xs text-stone-500 space-x-3">
+                          {cred.env && <span>ENV: <span className="font-mono">{cred.env}</span></span>}
+                          {cred.mountPath && <span>Mount: <span className="font-mono">{cred.mountPath}</span></span>}
+                        </div>
+                      )}
+                    </div>
+                  ))}
                 </div>
-              )}
-              {tmpl.workspaceDir && (
-                <div>
-                  <dt className="text-xs text-stone-400">Workspace Directory</dt>
-                  <dd className="mt-1 text-sm text-stone-700 font-mono">{tmpl.workspaceDir}</dd>
+              </div>
+            )}
+
+            {/* Plugins */}
+            {tmpl.plugins && tmpl.plugins.length > 0 && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
+                  Plugins ({tmpl.plugins.length})
+                </h3>
+                <div className="space-y-2">
+                  {tmpl.plugins.map((plugin, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800 font-mono">
+                          {plugin.name}
+                        </span>
+                        {plugin.target && (
+                          <span className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
+                            plugin.target === 'tui'
+                              ? 'bg-amber-50 text-amber-600 border-amber-200'
+                              : 'bg-teal-50 text-teal-600 border-teal-200'
+                          }`}>
+                            {plugin.target}
+                          </span>
+                        )}
+                      </div>
+                      {plugin.options && Object.keys(plugin.options).length > 0 && (
+                        <pre className="mt-2 text-[11px] text-stone-500 font-mono bg-stone-100 rounded p-2 overflow-x-auto">
+                          {JSON.stringify(plugin.options, null, 2)}
+                        </pre>
+                      )}
+                    </div>
+                  ))}
                 </div>
-              )}
-              {tmpl.serviceAccountName && (
-                <div>
-                  <dt className="text-xs text-stone-400">Service Account</dt>
-                  <dd className="mt-1 text-sm text-stone-700 font-mono">{tmpl.serviceAccountName}</dd>
+              </div>
+            )}
+
+            {/* OpenCode Config */}
+            {tmpl.config && Object.keys(tmpl.config).length > 0 && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
+                  OpenCode Config
+                </h3>
+                <pre className="text-xs text-stone-600 font-mono bg-stone-50 rounded-lg p-4 border border-stone-100 overflow-x-auto">
+                  {JSON.stringify(tmpl.config, null, 2)}
+                </pre>
+              </div>
+            )}
+
+            {/* Contexts */}
+            {tmpl.contexts && tmpl.contexts.length > 0 && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
+                  Contexts ({tmpl.contexts.length})
+                </h3>
+                <div className="space-y-2">
+                  {tmpl.contexts.map((ctx, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800">
+                          {ctx.name || `Context ${idx + 1}`}
+                        </span>
+                        <span className="text-[11px] px-2 py-0.5 rounded-md bg-sky-50 text-sky-600 border border-sky-200 font-medium">
+                          {ctx.type}
+                        </span>
+                      </div>
+                      {ctx.description && (
+                        <p className="mt-1 text-xs text-stone-500">{ctx.description}</p>
+                      )}
+                      {ctx.mountPath && (
+                        <p className="mt-1 text-[11px] text-stone-400 font-mono">
+                          mount: {ctx.mountPath}
+                        </p>
+                      )}
+                      {ctx.sync && ctx.sync.enabled && (
+                        <div className="mt-1.5 flex items-center gap-2">
+                          <span className="text-[11px] px-1.5 py-0.5 rounded bg-emerald-50 text-emerald-600 border border-emerald-200 font-medium">
+                            sync: {ctx.sync.policy || 'HotReload'}
+                          </span>
+                          {ctx.sync.interval && (
+                            <span className="text-[11px] text-stone-400">
+                              every {ctx.sync.interval}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  ))}
                 </div>
-              )}
-            </div>
+              </div>
+            )}
           </div>
+        )}
 
-          {/* Referencing Agents */}
-          <div>
-            <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
-              Referencing Agents ({referencingAgents.length})
-            </h3>
+        {/* Agents Tab */}
+        {activeTab === 'agents' && (
+          <div className="px-6 py-5">
             {referencingAgents.length === 0 ? (
-              <p className="text-sm text-stone-400">No agents are using this template yet.</p>
+              <div className="text-center py-8">
+                <svg className="w-10 h-10 text-stone-300 mx-auto mb-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="5" y="11" width="14" height="10" rx="2" />
+                  <circle cx="9" cy="16" r="1" />
+                  <circle cx="15" cy="16" r="1" />
+                  <path d="M9 7L9 4M15 7L15 4M12 7L12 2" />
+                </svg>
+                <p className="text-sm text-stone-400">No agents are using this template yet.</p>
+                <Link
+                  to={`/agents/create?template=${tmpl.namespace}/${tmpl.name}`}
+                  className="inline-flex items-center gap-1.5 mt-3 px-3 py-1.5 text-xs font-medium text-primary-600 bg-primary-50 rounded-lg hover:bg-primary-100 transition-colors"
+                >
+                  Create Agent from this Template
+                </Link>
+              </div>
             ) : (
               <div className="space-y-2">
                 {referencingAgents.map((agent) => (
@@ -183,161 +422,24 @@ function AgentTemplateDetailPage() {
               </div>
             )}
           </div>
+        )}
 
-          {/* Conditions */}
-          {tmpl.conditions && tmpl.conditions.length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Conditions</h3>
-              <div className="space-y-2">
-                {tmpl.conditions.map((condition, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800">{condition.type}</span>
-                      <span className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
-                        condition.status === 'True'
-                          ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
-                          : 'bg-stone-50 text-stone-500 border-stone-200'
-                      }`}>
-                        {condition.status}
-                      </span>
-                    </div>
-                    {condition.reason && (
-                      <p className="text-xs text-stone-500 mt-1">Reason: {condition.reason}</p>
-                    )}
-                    {condition.message && (
-                      <p className="text-xs text-stone-400 mt-1">{condition.message}</p>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Credentials */}
-          {tmpl.credentials && tmpl.credentials.length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
-                Credentials ({tmpl.credentials.length})
-              </h3>
-              <div className="space-y-2">
-                {tmpl.credentials.map((cred, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800">{cred.name}</span>
-                      <span className="text-xs text-stone-400 font-mono">{cred.secretRef}</span>
-                    </div>
-                    {(cred.env || cred.mountPath) && (
-                      <div className="mt-1 text-xs text-stone-500 space-x-3">
-                        {cred.env && <span>ENV: <span className="font-mono">{cred.env}</span></span>}
-                        {cred.mountPath && <span>Mount: <span className="font-mono">{cred.mountPath}</span></span>}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Plugins */}
-          {tmpl.plugins && tmpl.plugins.length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
-                Plugins ({tmpl.plugins.length})
-              </h3>
-              <div className="space-y-2">
-                {tmpl.plugins.map((plugin, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800 font-mono">
-                        {plugin.name}
-                      </span>
-                      {plugin.target && (
-                        <span className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
-                          plugin.target === 'tui'
-                            ? 'bg-amber-50 text-amber-600 border-amber-200'
-                            : 'bg-teal-50 text-teal-600 border-teal-200'
-                        }`}>
-                          {plugin.target}
-                        </span>
-                      )}
-                    </div>
-                    {plugin.options && Object.keys(plugin.options).length > 0 && (
-                      <pre className="mt-2 text-[11px] text-stone-500 font-mono bg-stone-100 rounded p-2 overflow-x-auto">
-                        {JSON.stringify(plugin.options, null, 2)}
-                      </pre>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* OpenCode Config */}
-          {tmpl.config && Object.keys(tmpl.config).length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
-                OpenCode Config
-              </h3>
-              <pre className="text-xs text-stone-600 font-mono bg-stone-50 rounded-lg p-4 border border-stone-100 overflow-x-auto">
-                {JSON.stringify(tmpl.config, null, 2)}
-              </pre>
-            </div>
-          )}
-
-          {/* Contexts */}
-          {tmpl.contexts && tmpl.contexts.length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">
-                Contexts ({tmpl.contexts.length})
-              </h3>
-              <div className="space-y-2">
-                {tmpl.contexts.map((ctx, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800">
-                        {ctx.name || `Context ${idx + 1}`}
-                      </span>
-                      <span className="text-[11px] px-2 py-0.5 rounded-md bg-sky-50 text-sky-600 border border-sky-200 font-medium">
-                        {ctx.type}
-                      </span>
-                    </div>
-                    {ctx.description && (
-                      <p className="mt-1 text-xs text-stone-500">{ctx.description}</p>
-                    )}
-                    {ctx.mountPath && (
-                      <p className="mt-1 text-[11px] text-stone-400 font-mono">
-                        mount: {ctx.mountPath}
-                      </p>
-                    )}
-                    {ctx.sync && ctx.sync.enabled && (
-                      <div className="mt-1.5 flex items-center gap-2">
-                        <span className="text-[11px] px-1.5 py-0.5 rounded bg-emerald-50 text-emerald-600 border border-emerald-200 font-medium">
-                          sync: {ctx.sync.policy || 'HotReload'}
-                        </span>
-                        {ctx.sync.interval && (
-                          <span className="text-[11px] text-stone-400">
-                            every {ctx.sync.interval}
-                          </span>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-        </div>
+        {/* YAML Tab */}
+        {activeTab === 'yaml' && (
+          <div className="p-4">
+            <YamlViewer
+              queryKey={['agent-template', namespace!, name!]}
+              fetchYaml={() => api.getAgentTemplateYaml(namespace!, name!)}
+              onSave={async (yaml) => {
+                await api.updateAgentTemplateYaml(namespace!, name!, yaml);
+                refetch();
+              }}
+              defaultOpen
+              hideToggle
+            />
+          </div>
+        )}
       </div>
-
-      <YamlViewer
-        queryKey={['agent-template', namespace!, name!]}
-        fetchYaml={() => api.getAgentTemplateYaml(namespace!, name!)}
-        onSave={async (yaml) => {
-          await api.updateAgentTemplateYaml(namespace!, name!, yaml);
-          refetch();
-        }}
-      />
 
       <ConfirmDialog
         open={showDeleteDialog}

--- a/ui/src/pages/ConfigPage.tsx
+++ b/ui/src/pages/ConfigPage.tsx
@@ -1,11 +1,39 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useLocation } from 'react-router-dom';
 import api from '../api/client';
 import Labels from '../components/Labels';
 import Breadcrumbs from '../components/Breadcrumbs';
 import YamlViewer from '../components/YamlViewer';
 import CopyButton from '../components/CopyButton';
 import { DetailSkeleton } from '../components/Skeleton';
+
+type ConfigTabId = 'overview' | 'yaml';
+
+const CONFIG_TABS: { id: ConfigTabId; label: string; icon: React.ReactNode }[] = [
+  {
+    id: 'overview',
+    label: 'Overview',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="3" width="7" height="7" rx="1" />
+        <rect x="14" y="3" width="7" height="7" rx="1" />
+        <rect x="3" y="14" width="7" height="7" rx="1" />
+        <rect x="14" y="14" width="7" height="7" rx="1" />
+      </svg>
+    ),
+  },
+  {
+    id: 'yaml',
+    label: 'YAML',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+    ),
+  },
+];
 
 const CONFIG_TEMPLATE = `apiVersion: kubeopencode.io/v1alpha1
 kind: KubeOpenCodeConfig
@@ -18,10 +46,20 @@ spec:
 
 function ConfigPage() {
   const queryClient = useQueryClient();
+  const location = useLocation();
   const { data: config, isLoading, error } = useQuery({
     queryKey: ['config'],
     queryFn: () => api.getConfig(),
   });
+
+  const hashTab = location.hash.replace('#', '') as ConfigTabId;
+  const initialTab: ConfigTabId = ['overview', 'yaml'].includes(hashTab) ? hashTab : 'overview';
+  const [activeTab, setActiveTab] = useState<ConfigTabId>(initialTab);
+
+  const handleTabChange = (tab: ConfigTabId) => {
+    setActiveTab(tab);
+    window.history.replaceState(null, '', `${location.pathname}#${tab}`);
+  };
 
   if (isLoading) {
     return <DetailSkeleton />;
@@ -66,6 +104,7 @@ function ConfigPage() {
       <Breadcrumbs items={[{ label: 'Config' }]} />
 
       <div className="bg-white rounded-xl border-0 overflow-hidden shadow-card">
+        {/* Header */}
         <div className="px-6 py-5 border-b border-stone-100">
           <div className="flex items-center justify-between">
             <div>
@@ -78,118 +117,151 @@ function ConfigPage() {
           </div>
         </div>
 
-        <div className="px-6 py-5 space-y-6">
-          {/* System Image */}
-          <div>
-            <h3 className="text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider mb-4">
-              System Image
-            </h3>
-            {config.systemImage ? (
-              <div className="grid grid-cols-2 gap-x-6 gap-y-4">
-                {config.systemImage.image && (
-                  <div>
-                    <dt className="text-xs text-stone-400">Image</dt>
-                    <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
-                      {config.systemImage.image}
-                    </dd>
-                  </div>
-                )}
-                {config.systemImage.imagePullPolicy && (
-                  <div>
-                    <dt className="text-xs text-stone-400">Pull Policy</dt>
-                    <dd className="mt-1 text-sm text-stone-700">{config.systemImage.imagePullPolicy}</dd>
-                  </div>
-                )}
-              </div>
-            ) : (
-              <p className="text-sm text-stone-400">Using default system image</p>
-            )}
-          </div>
-
-          {/* Cleanup */}
-          <div>
-            <h3 className="text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider mb-4">
-              Task Cleanup
-            </h3>
-            {config.cleanup ? (
-              <div className="grid grid-cols-2 gap-x-6 gap-y-4">
-                <div>
-                  <dt className="text-xs text-stone-400">TTL After Finished</dt>
-                  <dd className="mt-1 text-sm text-stone-700">
-                    {config.cleanup.ttlSecondsAfterFinished != null
-                      ? formatDuration(config.cleanup.ttlSecondsAfterFinished)
-                      : <span className="text-stone-400">Not set</span>}
-                  </dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-stone-400">Max Retained Tasks (per namespace)</dt>
-                  <dd className="mt-1 text-sm text-stone-700">
-                    {config.cleanup.maxRetainedTasks != null
-                      ? config.cleanup.maxRetainedTasks
-                      : <span className="text-stone-400">Not set</span>}
-                  </dd>
-                </div>
-              </div>
-            ) : (
-              <p className="text-sm text-stone-400">No automatic cleanup configured</p>
-            )}
-          </div>
-
-          {/* Proxy */}
-          <div>
-            <h3 className="text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider mb-4">
-              Proxy
-            </h3>
-            {config.proxy ? (
-              <div className="space-y-3">
-                {config.proxy.httpProxy && (
-                  <div>
-                    <dt className="text-xs text-stone-400">HTTP Proxy</dt>
-                    <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100">
-                      {config.proxy.httpProxy}
-                    </dd>
-                  </div>
-                )}
-                {config.proxy.httpsProxy && (
-                  <div>
-                    <dt className="text-xs text-stone-400">HTTPS Proxy</dt>
-                    <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100">
-                      {config.proxy.httpsProxy}
-                    </dd>
-                  </div>
-                )}
-                {config.proxy.noProxy && (
-                  <div>
-                    <dt className="text-xs text-stone-400">No Proxy</dt>
-                    <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
-                      {config.proxy.noProxy}
-                    </dd>
-                  </div>
-                )}
-              </div>
-            ) : (
-              <p className="text-sm text-stone-400">No proxy configured</p>
-            )}
-          </div>
-
-          {/* Labels */}
-          {config.labels && Object.keys(config.labels).length > 0 && (
-            <div>
-              <h3 className="text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider mb-3">Labels</h3>
-              <Labels labels={config.labels} />
-            </div>
-          )}
+        {/* Tab Bar */}
+        <div className="px-6 border-b border-stone-100 bg-stone-50/50">
+          <nav className="flex space-x-1 -mb-px" aria-label="Tabs">
+            {CONFIG_TABS.map((tab) => {
+              const isActive = activeTab === tab.id;
+              return (
+                <button
+                  key={tab.id}
+                  onClick={() => handleTabChange(tab.id)}
+                  className={`flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium border-b-2 transition-colors ${
+                    isActive
+                      ? 'border-primary-600 text-primary-700'
+                      : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
+                  }`}
+                >
+                  <span className={isActive ? 'text-primary-600' : 'text-stone-400'}>{tab.icon}</span>
+                  {tab.label}
+                </button>
+              );
+            })}
+          </nav>
         </div>
-      </div>
 
-      <YamlViewer
-        queryKey={['config-yaml']}
-        fetchYaml={() => api.getConfigYaml()}
-        onSave={async (yaml) => {
-          await api.updateConfigYaml(yaml);
-          queryClient.invalidateQueries({ queryKey: ['config'] });
-        }}
-      />
+        {/* Overview Tab */}
+        {activeTab === 'overview' && (
+          <div className="px-6 py-5 space-y-6">
+            {/* System Image */}
+            <div>
+              <h3 className="text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider mb-4">
+                System Image
+              </h3>
+              {config.systemImage ? (
+                <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+                  {config.systemImage.image && (
+                    <div>
+                      <dt className="text-xs text-stone-400">Image</dt>
+                      <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
+                        {config.systemImage.image}
+                      </dd>
+                    </div>
+                  )}
+                  {config.systemImage.imagePullPolicy && (
+                    <div>
+                      <dt className="text-xs text-stone-400">Pull Policy</dt>
+                      <dd className="mt-1 text-sm text-stone-700">{config.systemImage.imagePullPolicy}</dd>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <p className="text-sm text-stone-400">Using default system image</p>
+              )}
+            </div>
+
+            {/* Cleanup */}
+            <div>
+              <h3 className="text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider mb-4">
+                Task Cleanup
+              </h3>
+              {config.cleanup ? (
+                <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+                  <div>
+                    <dt className="text-xs text-stone-400">TTL After Finished</dt>
+                    <dd className="mt-1 text-sm text-stone-700">
+                      {config.cleanup.ttlSecondsAfterFinished != null
+                        ? formatDuration(config.cleanup.ttlSecondsAfterFinished)
+                        : <span className="text-stone-400">Not set</span>}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-stone-400">Max Retained Tasks (per namespace)</dt>
+                    <dd className="mt-1 text-sm text-stone-700">
+                      {config.cleanup.maxRetainedTasks != null
+                        ? config.cleanup.maxRetainedTasks
+                        : <span className="text-stone-400">Not set</span>}
+                    </dd>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-stone-400">No automatic cleanup configured</p>
+              )}
+            </div>
+
+            {/* Proxy */}
+            <div>
+              <h3 className="text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider mb-4">
+                Proxy
+              </h3>
+              {config.proxy ? (
+                <div className="space-y-3">
+                  {config.proxy.httpProxy && (
+                    <div>
+                      <dt className="text-xs text-stone-400">HTTP Proxy</dt>
+                      <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100">
+                        {config.proxy.httpProxy}
+                      </dd>
+                    </div>
+                  )}
+                  {config.proxy.httpsProxy && (
+                    <div>
+                      <dt className="text-xs text-stone-400">HTTPS Proxy</dt>
+                      <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100">
+                        {config.proxy.httpsProxy}
+                      </dd>
+                    </div>
+                  )}
+                  {config.proxy.noProxy && (
+                    <div>
+                      <dt className="text-xs text-stone-400">No Proxy</dt>
+                      <dd className="mt-1 text-xs text-stone-700 font-mono bg-stone-50 px-3 py-2 rounded-lg border border-stone-100 break-all">
+                        {config.proxy.noProxy}
+                      </dd>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <p className="text-sm text-stone-400">No proxy configured</p>
+              )}
+            </div>
+
+            {/* Labels */}
+            {config.labels && Object.keys(config.labels).length > 0 && (
+              <div>
+                <h3 className="text-[11px] font-display font-medium text-stone-400 uppercase tracking-wider mb-3">Labels</h3>
+                <Labels labels={config.labels} />
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* YAML Tab */}
+        {activeTab === 'yaml' && (
+          <div className="p-4">
+            <YamlViewer
+              queryKey={['config-yaml']}
+              fetchYaml={() => api.getConfigYaml()}
+              onSave={async (yaml) => {
+                await api.updateConfigYaml(yaml);
+                queryClient.invalidateQueries({ queryKey: ['config'] });
+              }}
+              defaultOpen
+              hideToggle
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/ui/src/pages/CronTaskDetailPage.tsx
+++ b/ui/src/pages/CronTaskDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '../api/client';
 import StatusBadge from '../components/StatusBadge';
@@ -12,12 +12,59 @@ import { DetailSkeleton } from '../components/Skeleton';
 import { useToast } from '../contexts/ToastContext';
 import { describeCronExpression } from '../utils/cron';
 
+type CronTaskTabId = 'overview' | 'history' | 'yaml';
+
+const CRONTASK_TABS: { id: CronTaskTabId; label: string; icon: React.ReactNode }[] = [
+  {
+    id: 'overview',
+    label: 'Overview',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="3" width="7" height="7" rx="1" />
+        <rect x="14" y="3" width="7" height="7" rx="1" />
+        <rect x="3" y="14" width="7" height="7" rx="1" />
+        <rect x="14" y="14" width="7" height="7" rx="1" />
+      </svg>
+    ),
+  },
+  {
+    id: 'history',
+    label: 'Execution History',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+    ),
+  },
+  {
+    id: 'yaml',
+    label: 'YAML',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+    ),
+  },
+];
+
 function CronTaskDetailPage() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const { addToast } = useToast();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  const hashTab = location.hash.replace('#', '') as CronTaskTabId;
+  const initialTab: CronTaskTabId = ['overview', 'history', 'yaml'].includes(hashTab) ? hashTab : 'overview';
+  const [activeTab, setActiveTab] = useState<CronTaskTabId>(initialTab);
+
+  const handleTabChange = (tab: CronTaskTabId) => {
+    setActiveTab(tab);
+    window.history.replaceState(null, '', `${location.pathname}#${tab}`);
+  };
 
   const { data: cronTask, isLoading, error } = useQuery({
     queryKey: ['crontask', namespace, name],
@@ -126,6 +173,7 @@ function CronTaskDetailPage() {
       ]} />
 
       <div className="bg-white rounded-xl border-0 overflow-hidden shadow-card">
+        {/* Header */}
         <div className="px-6 py-5 border-b border-stone-100">
           <div className="flex items-center justify-between">
             <div>
@@ -181,234 +229,271 @@ function CronTaskDetailPage() {
           </div>
         </div>
 
-        <div className="px-6 py-5 space-y-5">
-          {/* Labels */}
-          {cronTask.labels && Object.keys(cronTask.labels).length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Labels</h3>
-              <Labels labels={cronTask.labels} />
-            </div>
-          )}
+        {/* Tab Bar */}
+        <div className="px-6 border-b border-stone-100 bg-stone-50/50">
+          <nav className="flex space-x-1 -mb-px" aria-label="Tabs">
+            {CRONTASK_TABS.map((tab) => {
+              const isActive = activeTab === tab.id;
+              return (
+                <button
+                  key={tab.id}
+                  onClick={() => handleTabChange(tab.id)}
+                  className={`flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium border-b-2 transition-colors ${
+                    isActive
+                      ? 'border-primary-600 text-primary-700'
+                      : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
+                  }`}
+                >
+                  <span className={isActive ? 'text-primary-600' : 'text-stone-400'}>{tab.icon}</span>
+                  {tab.label}
+                  {tab.id === 'history' && history.length > 0 && (
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${
+                      isActive ? 'bg-primary-100 text-primary-600' : 'bg-stone-200 text-stone-500'
+                    }`}>
+                      {historyData?.pagination?.totalCount || history.length}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
 
-          {/* Agent */}
-          {cronTask.taskTemplate.agentRef && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Agent</h3>
-              <Link
-                to={`/agents/${cronTask.namespace}/${cronTask.taskTemplate.agentRef.name}`}
-                className="inline-flex items-center gap-2 bg-violet-50 rounded-lg px-4 py-2.5 border border-violet-200 hover:border-violet-300 transition-colors group"
-              >
-                <svg className="w-4 h-4 text-violet-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="5" y="11" width="14" height="10" rx="2" />
-                  <circle cx="9" cy="16" r="1" />
-                  <circle cx="15" cy="16" r="1" />
-                  <path d="M9 7L9 4M15 7L15 4M12 7L12 2" />
-                </svg>
-                <span className="text-sm font-medium text-violet-700 group-hover:text-violet-800">{cronTask.taskTemplate.agentRef.name}</span>
-                <svg className="w-3.5 h-3.5 text-violet-400 group-hover:text-violet-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </Link>
-            </div>
-          )}
-
-          {/* Template */}
-          {cronTask.taskTemplate.templateRef && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Template</h3>
-              <Link
-                to={`/templates/${cronTask.namespace}/${cronTask.taskTemplate.templateRef.name}`}
-                className="inline-flex items-center gap-2 bg-teal-50 rounded-lg px-4 py-2.5 border border-teal-200 hover:border-teal-300 transition-colors group"
-              >
-                <svg className="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="3" y="3" width="7" height="7" rx="1" />
-                  <rect x="14" y="3" width="7" height="7" rx="1" />
-                  <rect x="3" y="14" width="7" height="7" rx="1" />
-                  <rect x="14" y="14" width="7" height="7" rx="1" />
-                </svg>
-                <span className="text-sm font-medium text-teal-700 group-hover:text-teal-800">{cronTask.taskTemplate.templateRef.name}</span>
-                <svg className="w-3.5 h-3.5 text-teal-400 group-hover:text-teal-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </Link>
-            </div>
-          )}
-
-          {/* Schedule */}
-          <div>
-            <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Schedule</h3>
-            <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+        {/* Overview Tab */}
+        {activeTab === 'overview' && (
+          <div className="px-6 py-5 space-y-5">
+            {/* Labels */}
+            {cronTask.labels && Object.keys(cronTask.labels).length > 0 && (
               <div>
-                <dt className="text-xs text-stone-400">Cron Expression</dt>
-                <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.schedule}</dd>
-                {describeCronExpression(cronTask.schedule) && (
-                  <dd className="mt-0.5 text-xs text-primary-600">{describeCronExpression(cronTask.schedule)}</dd>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Labels</h3>
+                <Labels labels={cronTask.labels} />
+              </div>
+            )}
+
+            {/* Agent */}
+            {cronTask.taskTemplate.agentRef && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Agent</h3>
+                <Link
+                  to={`/agents/${cronTask.namespace}/${cronTask.taskTemplate.agentRef.name}`}
+                  className="inline-flex items-center gap-2 bg-violet-50 rounded-lg px-4 py-2.5 border border-violet-200 hover:border-violet-300 transition-colors group"
+                >
+                  <svg className="w-4 h-4 text-violet-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="5" y="11" width="14" height="10" rx="2" />
+                    <circle cx="9" cy="16" r="1" />
+                    <circle cx="15" cy="16" r="1" />
+                    <path d="M9 7L9 4M15 7L15 4M12 7L12 2" />
+                  </svg>
+                  <span className="text-sm font-medium text-violet-700 group-hover:text-violet-800">{cronTask.taskTemplate.agentRef.name}</span>
+                  <svg className="w-3.5 h-3.5 text-violet-400 group-hover:text-violet-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </Link>
+              </div>
+            )}
+
+            {/* Template */}
+            {cronTask.taskTemplate.templateRef && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Template</h3>
+                <Link
+                  to={`/templates/${cronTask.namespace}/${cronTask.taskTemplate.templateRef.name}`}
+                  className="inline-flex items-center gap-2 bg-teal-50 rounded-lg px-4 py-2.5 border border-teal-200 hover:border-teal-300 transition-colors group"
+                >
+                  <svg className="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="3" y="3" width="7" height="7" rx="1" />
+                    <rect x="14" y="3" width="7" height="7" rx="1" />
+                    <rect x="3" y="14" width="7" height="7" rx="1" />
+                    <rect x="14" y="14" width="7" height="7" rx="1" />
+                  </svg>
+                  <span className="text-sm font-medium text-teal-700 group-hover:text-teal-800">{cronTask.taskTemplate.templateRef.name}</span>
+                  <svg className="w-3.5 h-3.5 text-teal-400 group-hover:text-teal-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </Link>
+              </div>
+            )}
+
+            {/* Schedule */}
+            <div>
+              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Schedule</h3>
+              <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+                <div>
+                  <dt className="text-xs text-stone-400">Cron Expression</dt>
+                  <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.schedule}</dd>
+                  {describeCronExpression(cronTask.schedule) && (
+                    <dd className="mt-0.5 text-xs text-primary-600">{describeCronExpression(cronTask.schedule)}</dd>
+                  )}
+                </div>
+                <div>
+                  <dt className="text-xs text-stone-400">Timezone</dt>
+                  <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.timeZone || 'UTC'}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-stone-400">Concurrency Policy</dt>
+                  <dd className="mt-1 text-sm text-stone-800">{cronTask.concurrencyPolicy}</dd>
+                </div>
+                {cronTask.startingDeadlineSeconds !== undefined && (
+                  <div>
+                    <dt className="text-xs text-stone-400">Starting Deadline</dt>
+                    <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.startingDeadlineSeconds}s</dd>
+                  </div>
                 )}
               </div>
-              <div>
-                <dt className="text-xs text-stone-400">Timezone</dt>
-                <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.timeZone || 'UTC'}</dd>
-              </div>
-              <div>
-                <dt className="text-xs text-stone-400">Concurrency Policy</dt>
-                <dd className="mt-1 text-sm text-stone-800">{cronTask.concurrencyPolicy}</dd>
-              </div>
-              {cronTask.startingDeadlineSeconds !== undefined && (
-                <div>
-                  <dt className="text-xs text-stone-400">Starting Deadline</dt>
-                  <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.startingDeadlineSeconds}s</dd>
-                </div>
-              )}
             </div>
-          </div>
 
-          {/* Execution */}
-          <div>
-            <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Execution</h3>
-            <div className="grid grid-cols-2 gap-x-6 gap-y-4">
-              <div>
-                <dt className="text-xs text-stone-400">Total Executions</dt>
-                <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.totalExecutions}</dd>
-              </div>
-              <div>
-                <dt className="text-xs text-stone-400">Running Tasks</dt>
-                <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.active}</dd>
-              </div>
-              <div>
-                <dt className="text-xs text-stone-400">Last Scheduled</dt>
-                <dd className="mt-1 text-sm text-stone-800">
-                  {cronTask.lastScheduleTime ? <TimeAgo date={cronTask.lastScheduleTime} /> : '-'}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-xs text-stone-400">Next Schedule</dt>
-                <dd className="mt-1 text-sm text-stone-800">
-                  {cronTask.nextScheduleTime ? <TimeAgo date={cronTask.nextScheduleTime} /> : '-'}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-xs text-stone-400">Created</dt>
-                <dd className="mt-1 text-sm text-stone-800">
-                  <TimeAgo date={cronTask.createdAt} />
-                </dd>
-              </div>
-              {cronTask.maxRetainedTasks !== undefined && cronTask.maxRetainedTasks > 0 && (
-                <div>
-                  <dt className="text-xs text-stone-400">Max Retained Tasks</dt>
-                  <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.maxRetainedTasks}</dd>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {cronTask.taskTemplate.description && (
+            {/* Execution */}
             <div>
-              <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-2">Description</dt>
-              <dd className="bg-stone-50 rounded-lg p-4 border border-stone-100">
-                <pre className="text-sm text-stone-700 whitespace-pre-wrap font-body leading-relaxed">{cronTask.taskTemplate.description}</pre>
-              </dd>
-            </div>
-          )}
-
-          {cronTask.conditions && cronTask.conditions.length > 0 && (
-            <div>
-              <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-2">Conditions</dt>
-              <dd className="space-y-2">
-                {cronTask.conditions.map((condition, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800">{condition.type}</span>
-                      <span
-                        className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
-                          condition.status === 'True'
-                            ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
-                            : 'bg-stone-50 text-stone-500 border-stone-200'
-                        }`}
-                      >
-                        {condition.status}
-                      </span>
-                    </div>
-                    {condition.reason && (
-                      <p className="text-xs text-stone-500 mt-1">Reason: {condition.reason}</p>
-                    )}
-                    {condition.message && (
-                      <p className="text-xs text-stone-400 mt-1">{condition.message}</p>
-                    )}
+              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-4">Execution</h3>
+              <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+                <div>
+                  <dt className="text-xs text-stone-400">Total Executions</dt>
+                  <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.totalExecutions}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-stone-400">Running Tasks</dt>
+                  <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.active}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-stone-400">Last Scheduled</dt>
+                  <dd className="mt-1 text-sm text-stone-800">
+                    {cronTask.lastScheduleTime ? <TimeAgo date={cronTask.lastScheduleTime} /> : '-'}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-stone-400">Next Schedule</dt>
+                  <dd className="mt-1 text-sm text-stone-800">
+                    {cronTask.nextScheduleTime ? <TimeAgo date={cronTask.nextScheduleTime} /> : '-'}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-stone-400">Created</dt>
+                  <dd className="mt-1 text-sm text-stone-800">
+                    <TimeAgo date={cronTask.createdAt} />
+                  </dd>
+                </div>
+                {cronTask.maxRetainedTasks !== undefined && cronTask.maxRetainedTasks > 0 && (
+                  <div>
+                    <dt className="text-xs text-stone-400">Max Retained Tasks</dt>
+                    <dd className="mt-1 text-sm text-stone-800 font-mono">{cronTask.maxRetainedTasks}</dd>
                   </div>
-                ))}
-              </dd>
+                )}
+              </div>
             </div>
-          )}
-        </div>
-      </div>
 
-      <YamlViewer
-        queryKey={['crontask-yaml', namespace!, name!]}
-        fetchYaml={() => api.getCronTaskYaml(namespace!, name!)}
-        onSave={async (yaml) => {
-          await api.updateCronTaskYaml(namespace!, name!, yaml);
-          queryClient.invalidateQueries({ queryKey: ['crontask', namespace, name] });
-        }}
-      />
+            {cronTask.taskTemplate.description && (
+              <div>
+                <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-2">Description</dt>
+                <dd className="bg-stone-50 rounded-lg p-4 border border-stone-100">
+                  <pre className="text-sm text-stone-700 whitespace-pre-wrap font-body leading-relaxed">{cronTask.taskTemplate.description}</pre>
+                </dd>
+              </div>
+            )}
 
-      {/* Execution History */}
-      <div className="mt-6 bg-white rounded-xl border-0 overflow-hidden shadow-card">
-        <div className="px-6 py-4 border-b border-stone-100">
-          <h3 className="font-display text-base font-semibold text-stone-900">Execution History</h3>
-          <p className="text-xs text-stone-400 mt-0.5">Tasks created by this CronTask</p>
-        </div>
-
-        {history.length === 0 ? (
-          <div className="px-6 py-12 text-center text-stone-400 text-sm">
-            No executions yet.
+            {cronTask.conditions && cronTask.conditions.length > 0 && (
+              <div>
+                <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-2">Conditions</dt>
+                <dd className="space-y-2">
+                  {cronTask.conditions.map((condition, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800">{condition.type}</span>
+                        <span
+                          className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
+                            condition.status === 'True'
+                              ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
+                              : 'bg-stone-50 text-stone-500 border-stone-200'
+                          }`}
+                        >
+                          {condition.status}
+                        </span>
+                      </div>
+                      {condition.reason && (
+                        <p className="text-xs text-stone-500 mt-1">Reason: {condition.reason}</p>
+                      )}
+                      {condition.message && (
+                        <p className="text-xs text-stone-400 mt-1">{condition.message}</p>
+                      )}
+                    </div>
+                  ))}
+                </dd>
+              </div>
+            )}
           </div>
-        ) : (
-          <table className="min-w-full divide-y divide-stone-100">
-            <thead className="bg-stone-50/60">
-              <tr>
-                <th className="px-5 py-3 text-left text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">
-                  Name
-                </th>
-                <th className="px-5 py-3 text-left text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">
-                  Status
-                </th>
-                <th className="px-5 py-3 text-left text-xs font-display font-semibold text-stone-500 uppercase tracking-wider hidden sm:table-cell">
-                  Duration
-                </th>
-                <th className="px-5 py-3 text-left text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">
-                  Created
-                </th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-stone-100">
-              {history.map((task) => (
-                <tr key={`${task.namespace}/${task.name}`} className="hover:bg-stone-50/60 transition-colors">
-                  <td className="px-5 py-3.5 whitespace-nowrap">
-                    <Link
-                      to={`/tasks/${task.namespace}/${task.name}`}
-                      className="text-stone-800 hover:text-primary-600 font-medium text-sm transition-colors"
-                    >
-                      {task.name}
-                    </Link>
-                  </td>
-                  <td className="px-5 py-3.5 whitespace-nowrap">
-                    <StatusBadge phase={task.phase || 'Pending'} />
-                  </td>
-                  <td className="px-5 py-3.5 whitespace-nowrap text-sm text-stone-400 hidden sm:table-cell font-mono text-xs">
-                    {task.duration || '-'}
-                  </td>
-                  <td className="px-5 py-3.5 whitespace-nowrap text-xs text-stone-400">
-                    <TimeAgo date={task.createdAt} />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
         )}
 
-        {historyData?.pagination && historyData.pagination.totalCount > 20 && (
-          <div className="px-5 py-3 border-t border-stone-100 text-xs text-stone-400">
-            Showing {Math.min(20, historyData.pagination.totalCount)} of {historyData.pagination.totalCount} executions
+        {/* Execution History Tab */}
+        {activeTab === 'history' && (
+          <div>
+            {history.length === 0 ? (
+              <div className="px-6 py-12 text-center text-stone-400 text-sm">
+                No executions yet.
+              </div>
+            ) : (
+              <table className="min-w-full divide-y divide-stone-100">
+                <thead className="bg-stone-50/60">
+                  <tr>
+                    <th className="px-5 py-3 text-left text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">
+                      Name
+                    </th>
+                    <th className="px-5 py-3 text-left text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">
+                      Status
+                    </th>
+                    <th className="px-5 py-3 text-left text-xs font-display font-semibold text-stone-500 uppercase tracking-wider hidden sm:table-cell">
+                      Duration
+                    </th>
+                    <th className="px-5 py-3 text-left text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">
+                      Created
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-stone-100">
+                  {history.map((task) => (
+                    <tr key={`${task.namespace}/${task.name}`} className="hover:bg-stone-50/60 transition-colors">
+                      <td className="px-5 py-3.5 whitespace-nowrap">
+                        <Link
+                          to={`/tasks/${task.namespace}/${task.name}`}
+                          className="text-stone-800 hover:text-primary-600 font-medium text-sm transition-colors"
+                        >
+                          {task.name}
+                        </Link>
+                      </td>
+                      <td className="px-5 py-3.5 whitespace-nowrap">
+                        <StatusBadge phase={task.phase || 'Pending'} />
+                      </td>
+                      <td className="px-5 py-3.5 whitespace-nowrap text-sm text-stone-400 hidden sm:table-cell font-mono text-xs">
+                        {task.duration || '-'}
+                      </td>
+                      <td className="px-5 py-3.5 whitespace-nowrap text-xs text-stone-400">
+                        <TimeAgo date={task.createdAt} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+
+            {historyData?.pagination && historyData.pagination.totalCount > 20 && (
+              <div className="px-5 py-3 border-t border-stone-100 text-xs text-stone-400">
+                Showing {Math.min(20, historyData.pagination.totalCount)} of {historyData.pagination.totalCount} executions
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* YAML Tab */}
+        {activeTab === 'yaml' && (
+          <div className="p-4">
+            <YamlViewer
+              queryKey={['crontask-yaml', namespace!, name!]}
+              fetchYaml={() => api.getCronTaskYaml(namespace!, name!)}
+              onSave={async (yaml) => {
+                await api.updateCronTaskYaml(namespace!, name!, yaml);
+                queryClient.invalidateQueries({ queryKey: ['crontask', namespace, name] });
+              }}
+              defaultOpen
+              hideToggle
+            />
           </div>
         )}
       </div>

--- a/ui/src/pages/ShareTerminalPage.tsx
+++ b/ui/src/pages/ShareTerminalPage.tsx
@@ -11,9 +11,35 @@ interface ShareInfo {
   agentName: string;
   namespace: string;
   profile?: string;
+  expiresAt?: string;
 }
 
 type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'error';
+
+function formatExpiry(expiresAt: string): { text: string; isExpired: boolean; isUrgent: boolean } {
+  const now = Date.now();
+  const expiry = new Date(expiresAt).getTime();
+  const diff = expiry - now;
+
+  if (diff <= 0) {
+    return { text: 'Expired', isExpired: true, isUrgent: true };
+  }
+
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  let text: string;
+  if (days > 0) {
+    text = `Expires in ${days}d ${hours % 24}h`;
+  } else if (hours > 0) {
+    text = `Expires in ${hours}h ${minutes % 60}m`;
+  } else {
+    text = `Expires in ${minutes}m`;
+  }
+
+  return { text, isExpired: false, isUrgent: hours < 1 };
+}
 
 function ShareTerminalPage() {
   const { token } = useParams<{ token: string }>();
@@ -204,6 +230,20 @@ function ShareTerminalPage() {
           </div>
           <span className="text-sm text-stone-300 font-mono">{shareInfo.agentName}</span>
           <span className="text-[11px] text-stone-600">{shareInfo.namespace}</span>
+          {shareInfo.expiresAt && (() => {
+            const expiry = formatExpiry(shareInfo.expiresAt);
+            return (
+              <span className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
+                expiry.isExpired
+                  ? 'bg-red-500/10 text-red-400 border-red-500/20'
+                  : expiry.isUrgent
+                    ? 'bg-amber-500/10 text-amber-400 border-amber-500/20'
+                    : 'bg-stone-800 text-stone-400 border-stone-700'
+              }`}>
+                {expiry.text}
+              </span>
+            );
+          })()}
         </div>
         <div className="flex items-center space-x-1">
           <button

--- a/ui/src/pages/TaskDetailPage.tsx
+++ b/ui/src/pages/TaskDetailPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '../api/client';
 import StatusBadge from '../components/StatusBadge';
@@ -13,12 +13,61 @@ import YamlViewer from '../components/YamlViewer';
 import { DetailSkeleton } from '../components/Skeleton';
 import { useToast } from '../contexts/ToastContext';
 
+type TaskTabId = 'overview' | 'logs' | 'yaml';
+
+const TASK_TABS: { id: TaskTabId; label: string; icon: React.ReactNode }[] = [
+  {
+    id: 'overview',
+    label: 'Overview',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="3" width="7" height="7" rx="1" />
+        <rect x="14" y="3" width="7" height="7" rx="1" />
+        <rect x="3" y="14" width="7" height="7" rx="1" />
+        <rect x="14" y="14" width="7" height="7" rx="1" />
+      </svg>
+    ),
+  },
+  {
+    id: 'logs',
+    label: 'Logs',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <line x1="16" y1="13" x2="8" y2="13" />
+        <line x1="16" y1="17" x2="8" y2="17" />
+      </svg>
+    ),
+  },
+  {
+    id: 'yaml',
+    label: 'YAML',
+    icon: (
+      <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+    ),
+  },
+];
+
 function TaskDetailPage() {
   const { namespace, name } = useParams<{ namespace: string; name: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const { addToast } = useToast();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  const hashTab = location.hash.replace('#', '') as TaskTabId;
+  const initialTab: TaskTabId = ['overview', 'logs', 'yaml'].includes(hashTab) ? hashTab : 'overview';
+  const [activeTab, setActiveTab] = useState<TaskTabId>(initialTab);
+
+  const handleTabChange = (tab: TaskTabId) => {
+    setActiveTab(tab);
+    window.history.replaceState(null, '', `${location.pathname}#${tab}`);
+  };
 
   const deleteMutation = useMutation({
     mutationFn: () => api.deleteTask(namespace!, name!),
@@ -86,6 +135,8 @@ function TaskDetailPage() {
     );
   }
 
+  const hasLogs = task.phase === 'Running' || task.phase === 'Completed' || task.phase === 'Failed';
+
   return (
     <div className="animate-fade-in">
       <Breadcrumbs items={[
@@ -95,6 +146,7 @@ function TaskDetailPage() {
       ]} />
 
       <div className="bg-white rounded-xl border-0 overflow-hidden shadow-card">
+        {/* Header */}
         <div className="px-6 py-5 border-b border-stone-100">
           <div className="flex items-center justify-between">
             <div>
@@ -131,153 +183,188 @@ function TaskDetailPage() {
           </div>
         </div>
 
-        <div className="px-6 py-5 space-y-5">
-          {/* Labels */}
-          {task.labels && Object.keys(task.labels).length > 0 && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Labels</h3>
-              <Labels labels={task.labels} />
-            </div>
-          )}
+        {/* Tab Bar */}
+        <div className="px-6 border-b border-stone-100 bg-stone-50/50">
+          <nav className="flex space-x-1 -mb-px" aria-label="Tabs">
+            {TASK_TABS.map((tab) => {
+              const isActive = activeTab === tab.id;
+              if (tab.id === 'logs' && !hasLogs) return null;
+              return (
+                <button
+                  key={tab.id}
+                  onClick={() => handleTabChange(tab.id)}
+                  className={`flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium border-b-2 transition-colors ${
+                    isActive
+                      ? 'border-primary-600 text-primary-700'
+                      : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
+                  }`}
+                >
+                  <span className={isActive ? 'text-primary-600' : 'text-stone-400'}>{tab.icon}</span>
+                  {tab.label}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
 
-          {/* Agent */}
-          {task.agentRef && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Agent</h3>
-              <Link
-                to={`/agents/${task.namespace}/${task.agentRef.name}`}
-                className="inline-flex items-center gap-2 bg-violet-50 rounded-lg px-4 py-2.5 border border-violet-200 hover:border-violet-300 transition-colors group"
-              >
-                <svg className="w-4 h-4 text-violet-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="5" y="11" width="14" height="10" rx="2" />
-                  <circle cx="9" cy="16" r="1" />
-                  <circle cx="15" cy="16" r="1" />
-                  <path d="M9 7L9 4M15 7L15 4M12 7L12 2" />
-                </svg>
-                <span className="text-sm font-medium text-violet-700 group-hover:text-violet-800">{task.agentRef.name}</span>
-                <svg className="w-3.5 h-3.5 text-violet-400 group-hover:text-violet-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </Link>
-            </div>
-          )}
-
-          {/* Template */}
-          {task.templateRef && (
-            <div>
-              <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Template</h3>
-              <Link
-                to={`/templates/${task.namespace}/${task.templateRef.name}`}
-                className="inline-flex items-center gap-2 bg-teal-50 rounded-lg px-4 py-2.5 border border-teal-200 hover:border-teal-300 transition-colors group"
-              >
-                <svg className="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="3" y="3" width="7" height="7" rx="1" />
-                  <rect x="14" y="3" width="7" height="7" rx="1" />
-                  <rect x="3" y="14" width="7" height="7" rx="1" />
-                  <rect x="14" y="14" width="7" height="7" rx="1" />
-                </svg>
-                <span className="text-sm font-medium text-teal-700 group-hover:text-teal-800">{task.templateRef.name}</span>
-                <svg className="w-3.5 h-3.5 text-teal-400 group-hover:text-teal-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </Link>
-            </div>
-          )}
-
-          <div className="grid grid-cols-2 gap-x-6 gap-y-4">
-            <div>
-              <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">Duration</dt>
-              <dd className="mt-1.5 text-sm text-stone-800 font-mono text-xs">{task.duration || '-'}</dd>
-            </div>
-            <div>
-              <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">Start Time</dt>
-              <dd className="mt-1.5 text-sm text-stone-800">
-                {task.startTime ? <TimeAgo date={task.startTime} /> : '-'}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">Completion</dt>
-              <dd className="mt-1.5 text-sm text-stone-800">
-                {task.completionTime ? <TimeAgo date={task.completionTime} /> : '-'}
-              </dd>
-            </div>
-            {task.timeout && (
+        {/* Overview Tab */}
+        {activeTab === 'overview' && (
+          <div className="px-6 py-5 space-y-5">
+            {/* Labels */}
+            {task.labels && Object.keys(task.labels).length > 0 && (
               <div>
-                <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">Timeout</dt>
-                <dd className="mt-1.5 text-sm text-stone-800 font-mono text-xs">{task.timeout}</dd>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Labels</h3>
+                <Labels labels={task.labels} />
               </div>
             )}
-            {task.podName && (
+
+            {/* Agent */}
+            {task.agentRef && (
               <div>
-                <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">Pod</dt>
-                <dd className="mt-1.5 text-sm text-stone-800 font-mono text-xs">
-                  {task.namespace}/{task.podName}
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Agent</h3>
+                <Link
+                  to={`/agents/${task.namespace}/${task.agentRef.name}`}
+                  className="inline-flex items-center gap-2 bg-violet-50 rounded-lg px-4 py-2.5 border border-violet-200 hover:border-violet-300 transition-colors group"
+                >
+                  <svg className="w-4 h-4 text-violet-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="5" y="11" width="14" height="10" rx="2" />
+                    <circle cx="9" cy="16" r="1" />
+                    <circle cx="15" cy="16" r="1" />
+                    <path d="M9 7L9 4M15 7L15 4M12 7L12 2" />
+                  </svg>
+                  <span className="text-sm font-medium text-violet-700 group-hover:text-violet-800">{task.agentRef.name}</span>
+                  <svg className="w-3.5 h-3.5 text-violet-400 group-hover:text-violet-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </Link>
+              </div>
+            )}
+
+            {/* Template */}
+            {task.templateRef && (
+              <div>
+                <h3 className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-3">Template</h3>
+                <Link
+                  to={`/templates/${task.namespace}/${task.templateRef.name}`}
+                  className="inline-flex items-center gap-2 bg-teal-50 rounded-lg px-4 py-2.5 border border-teal-200 hover:border-teal-300 transition-colors group"
+                >
+                  <svg className="w-4 h-4 text-teal-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="3" y="3" width="7" height="7" rx="1" />
+                    <rect x="14" y="3" width="7" height="7" rx="1" />
+                    <rect x="3" y="14" width="7" height="7" rx="1" />
+                    <rect x="14" y="14" width="7" height="7" rx="1" />
+                  </svg>
+                  <span className="text-sm font-medium text-teal-700 group-hover:text-teal-800">{task.templateRef.name}</span>
+                  <svg className="w-3.5 h-3.5 text-teal-400 group-hover:text-teal-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M9 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </Link>
+              </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-x-6 gap-y-4">
+              <div>
+                <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">Duration</dt>
+                <dd className="mt-1.5 text-sm text-stone-800 font-mono text-xs">{task.duration || '-'}</dd>
+              </div>
+              <div>
+                <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">Start Time</dt>
+                <dd className="mt-1.5 text-sm text-stone-800">
+                  {task.startTime ? <TimeAgo date={task.startTime} /> : '-'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">Completion</dt>
+                <dd className="mt-1.5 text-sm text-stone-800">
+                  {task.completionTime ? <TimeAgo date={task.completionTime} /> : '-'}
+                </dd>
+              </div>
+              {task.timeout && (
+                <div>
+                  <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">Timeout</dt>
+                  <dd className="mt-1.5 text-sm text-stone-800 font-mono text-xs">{task.timeout}</dd>
+                </div>
+              )}
+              {task.podName && (
+                <div>
+                  <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider">Pod</dt>
+                  <dd className="mt-1.5 text-sm text-stone-800 font-mono text-xs">
+                    {task.namespace}/{task.podName}
+                  </dd>
+                </div>
+              )}
+            </div>
+
+            {task.description && (
+              <div>
+                <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-2">Description</dt>
+                <dd className="bg-stone-50 rounded-lg p-4 border border-stone-100">
+                  <pre className="text-sm text-stone-700 whitespace-pre-wrap font-body leading-relaxed">{task.description}</pre>
+                </dd>
+              </div>
+            )}
+
+            {/* Session Summary */}
+            {task.session && (
+              <SessionPanel session={task.session} />
+            )}
+
+            {task.conditions && task.conditions.length > 0 && (
+              <div>
+                <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-2">Conditions</dt>
+                <dd className="space-y-2">
+                  {task.conditions.map((condition, idx) => (
+                    <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm text-stone-800">{condition.type}</span>
+                        <span
+                          className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
+                            condition.status === 'True'
+                              ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
+                              : 'bg-stone-50 text-stone-500 border-stone-200'
+                          }`}
+                        >
+                          {condition.status}
+                        </span>
+                      </div>
+                      {condition.reason && (
+                        <p className="text-xs text-stone-500 mt-1">Reason: {condition.reason}</p>
+                      )}
+                      {condition.message && (
+                        <p className="text-xs text-stone-400 mt-1">{condition.message}</p>
+                      )}
+                    </div>
+                  ))}
                 </dd>
               </div>
             )}
           </div>
+        )}
 
-          {task.description && (
-            <div>
-              <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-2">Description</dt>
-              <dd className="bg-stone-50 rounded-lg p-4 border border-stone-100">
-                <pre className="text-sm text-stone-700 whitespace-pre-wrap font-body leading-relaxed">{task.description}</pre>
-              </dd>
-            </div>
-          )}
+        {/* Logs Tab */}
+        {activeTab === 'logs' && hasLogs && (
+          <div className="p-4">
+            <LogViewer
+              namespace={namespace!}
+              taskName={name!}
+              podName={task.podName}
+              isRunning={task.phase === 'Running'}
+            />
+          </div>
+        )}
 
-          {/* Session Summary */}
-          {task.session && (
-            <SessionPanel session={task.session} />
-          )}
-
-          {task.conditions && task.conditions.length > 0 && (
-            <div>
-              <dt className="text-xs font-display font-semibold text-stone-500 uppercase tracking-wider mb-2">Conditions</dt>
-              <dd className="space-y-2">
-                {task.conditions.map((condition, idx) => (
-                  <div key={idx} className="bg-stone-50 rounded-lg p-3 border border-stone-100">
-                    <div className="flex items-center justify-between">
-                      <span className="font-medium text-sm text-stone-800">{condition.type}</span>
-                      <span
-                        className={`text-[11px] px-2 py-0.5 rounded-md border font-medium ${
-                          condition.status === 'True'
-                            ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
-                            : 'bg-stone-50 text-stone-500 border-stone-200'
-                        }`}
-                      >
-                        {condition.status}
-                      </span>
-                    </div>
-                    {condition.reason && (
-                      <p className="text-xs text-stone-500 mt-1">Reason: {condition.reason}</p>
-                    )}
-                    {condition.message && (
-                      <p className="text-xs text-stone-400 mt-1">{condition.message}</p>
-                    )}
-                  </div>
-                ))}
-              </dd>
-            </div>
-          )}
-        </div>
+        {/* YAML Tab */}
+        {activeTab === 'yaml' && (
+          <div className="p-4">
+            <YamlViewer
+              queryKey={['task', namespace!, name!]}
+              fetchYaml={() => api.getTaskYaml(namespace!, name!)}
+              defaultOpen
+              hideToggle
+            />
+          </div>
+        )}
       </div>
-
-      <YamlViewer
-        queryKey={['task', namespace!, name!]}
-        fetchYaml={() => api.getTaskYaml(namespace!, name!)}
-      />
-
-      {(task.phase === 'Running' || task.phase === 'Completed' || task.phase === 'Failed') && (
-        <div className="mt-6">
-          <LogViewer
-            namespace={namespace!}
-            taskName={name!}
-            podName={task.podName}
-            isRunning={task.phase === 'Running'}
-          />
-        </div>
-      )}
 
       <ConfirmDialog
         open={showDeleteDialog}

--- a/ui/src/pages/__tests__/AgentDetailPage.test.tsx
+++ b/ui/src/pages/__tests__/AgentDetailPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../../test/utils';
 import AgentDetailPage from '../AgentDetailPage';
 import { Route, Routes } from 'react-router-dom';
@@ -139,7 +140,15 @@ describe('AgentDetailPage', () => {
   });
 
   it('renders YamlViewer', async () => {
+    const user = userEvent.setup();
     renderAgentDetailPage('default', 'opencode-agent');
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'opencode-agent' })).toBeInTheDocument();
+    });
+
+    // Click the YAML tab
+    await user.click(screen.getByRole('button', { name: /YAML/i }));
 
     await waitFor(() => {
       expect(screen.getByTestId('yaml-viewer')).toBeInTheDocument();

--- a/ui/src/pages/__tests__/TaskDetailPage.test.tsx
+++ b/ui/src/pages/__tests__/TaskDetailPage.test.tsx
@@ -98,7 +98,15 @@ describe('TaskDetailPage', () => {
   });
 
   it('renders LogViewer for running tasks', async () => {
+    const user = userEvent.setup();
     renderTaskDetailPage('default', 'fix-auth-bug');
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'fix-auth-bug' })).toBeInTheDocument();
+    });
+
+    // Click the Logs tab
+    await user.click(screen.getByRole('button', { name: /Logs/i }));
 
     await waitFor(() => {
       expect(screen.getByTestId('log-viewer')).toBeInTheDocument();
@@ -106,7 +114,15 @@ describe('TaskDetailPage', () => {
   });
 
   it('renders YamlViewer', async () => {
+    const user = userEvent.setup();
     renderTaskDetailPage('default', 'fix-auth-bug');
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'fix-auth-bug' })).toBeInTheDocument();
+    });
+
+    // Click the YAML tab
+    await user.click(screen.getByRole('button', { name: /YAML/i }));
 
     await waitFor(() => {
       expect(screen.getByTestId('yaml-viewer')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Refactor all 5 resource detail pages (Agent, Task, CronTask, AgentTemplate, Config) from linear scrolling layouts to a consistent tab-based navigation pattern
- Promote Terminal and Share Link from buried page sections to first-class tabs on the Agent detail page
- Add share link UX improvements: expiry display, IP validation, and explicit "No expiration" / "All IPs allowed" status

## Changes

### Tab Layout (all detail pages)

| Page | Tabs |
|------|------|
| Agent | Overview, Terminal, Share, YAML |
| Task | Overview, Logs, YAML |
| CronTask | Overview, Execution History, YAML |
| AgentTemplate | Overview, Agents, YAML |
| Config | Overview, YAML |

- Tab state persisted via URL hash (`#terminal`, `#yaml`, etc.) for deep linking
- Conditional tabs: Terminal only when server ready, Logs only when task has output
- Badge counts on Execution History and Agents tabs
- Green dot indicator on Share tab when share link is active

### Share Link Enhancements

- **Share tab**: Promoted from a section in Overview to its own tab (Agent detail)
- **Expiry display**: Share terminal page header shows countdown with color coding (normal/urgent/expired)
- **IP validation**: CIDR format validation on the allowed IPs input with inline error messages
- **Empty state clarity**: When share is enabled, explicitly shows "No expiration" and "All IPs allowed" instead of hiding empty fields
- **Backend**: `ShareInfoResponse` now includes `expiresAt` field

### UI Polish

- YAML tab: removed collapsible toggle button (`hideToggle` prop), content auto-expands since it has its own tab
- YAML editor and log viewer: increased viewport height (`calc(100vh - ...)`) for better readability when in dedicated tabs
- Terminal: `defaultMode` prop allows auto-expand when rendered in Terminal tab
- Task list: cost column shows `-` instead of `$0.0000` for zero or missing cost

## Files Changed

**Backend (2 files)**:
- `internal/server/types/types.go` — Add `ExpiresAt` to `ShareInfoResponse`
- `internal/server/handlers/share_handler.go` — Populate `expiresAt` from agent spec

**UI Components (4 files)**:
- `ui/src/components/TerminalPanel.tsx` — Add `defaultMode` prop
- `ui/src/components/YamlViewer.tsx` — Add `defaultOpen`, `hideToggle` props
- `ui/src/components/LogViewer.tsx` — Increase default log area height
- `ui/src/components/SessionPanel.tsx` — Show `-` for zero cost

**UI Pages (6 files)**:
- `ui/src/pages/AgentDetailPage.tsx` — Tab layout + Share tab + IP validation
- `ui/src/pages/TaskDetailPage.tsx` — Tab layout
- `ui/src/pages/CronTaskDetailPage.tsx` — Tab layout
- `ui/src/pages/AgentTemplateDetailPage.tsx` — Tab layout
- `ui/src/pages/ConfigPage.tsx` — Tab layout
- `ui/src/pages/ShareTerminalPage.tsx` — Expiry display in header