### PR TITLE
fix(deps): resolve 5 high-severity Dependabot alerts

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -62,7 +62,8 @@
     "overrides": {
       "lodash": ">=4.18.0",
       "follow-redirects": ">=1.16.0",
-      "uuid": ">=11.1.1"
+      "uuid": ">=11.1.1",
+      "fast-uri": ">=3.1.2"
     }
   }
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   lodash: '>=4.18.0'
   follow-redirects: '>=1.16.0'
   uuid: '>=11.1.1'
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -1434,8 +1435,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -3878,7 +3879,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4370,7 +4371,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastest-levenshtein@1.0.16: {}
 

--- a/website/package.json
+++ b/website/package.json
@@ -53,7 +53,9 @@
       "lodash-es": ">=4.18.0",
       "follow-redirects": ">=1.16.0",
       "uuid": ">=11.1.1",
-      "postcss": ">=8.5.10"
+      "postcss": ">=8.5.10",
+      "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+      "fast-uri": ">=3.1.2"
     }
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -12,6 +12,8 @@ overrides:
   follow-redirects: '>=1.16.0'
   uuid: '>=11.1.1'
   postcss: '>=8.5.10'
+  '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -462,8 +464,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2981,8 +2983,8 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6001,7 +6003,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -6264,7 +6266,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
@@ -8385,7 +8387,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9525,7 +9527,7 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Fix all 5 open high-severity Dependabot alerts by adding `pnpm.overrides` to pin transitive dependencies to patched versions
- **`fast-uri`** >=3.1.2 in both `ui/` and `website/` — fixes CVE-2026-6321 (path traversal) and CVE-2026-6322 (host confusion)
- **`@babel/plugin-transform-modules-systemjs`** >=7.29.4 in `website/` — fixes CVE-2026-44728 (arbitrary code generation)

## Details

All 5 vulnerabilities are in transitive dependencies (not direct):

| Alert | Package | CVE | Manifest | Old | Patched |
|-------|---------|-----|----------|-----|---------|
| #51 | `@babel/plugin-transform-modules-systemjs` | CVE-2026-44728 | `website/pnpm-lock.yaml` | 7.29.0 | 7.29.4 |
| #50 | `fast-uri` | CVE-2026-6322 | `website/pnpm-lock.yaml` | 3.1.0 | 3.1.2 |
| #49 | `fast-uri` | CVE-2026-6322 | `ui/pnpm-lock.yaml` | 3.1.0 | 3.1.2 |
| #47 | `fast-uri` | CVE-2026-6321 | `website/pnpm-lock.yaml` | 3.1.0 | 3.1.2 |
| #46 | `fast-uri` | CVE-2026-6321 | `ui/pnpm-lock.yaml` | 3.1.0 | 3.1.2 |

This follows the same `pnpm.overrides` pattern already used in the project for previous Dependabot fixes (lodash, postcss, dompurify, follow-redirects, etc.).