### PR TITLE
chore: release v0.1.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,7 +377,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.1.2
+- **Version**: v0.1.3
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= v0.1.2
+VERSION ?= v0.1.3
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.14.41
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= v0.1.2
+VERSION ?= v0.1.3
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.1.2
-appVersion: "v0.1.2"
+version: 0.1.3
+appVersion: "v0.1.3"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Summary

Prepare v0.1.3 release.

- Update `VERSION` to `v0.1.3` in `Makefile` and `agents/Makefile`
- Update `Chart.yaml` version (`0.1.3`) and appVersion (`v0.1.3`)
- Update `AGENTS.md` project status version

## Changes since v0.1.2

- feat(ui): refactor all detail pages to tab layout and enhance share link (#209)
- feat: P1 UI improvements — empty states, dashboard stats, task timeout, cron editor, and form consistency (#208)
- feat: add Task session summary UI and fix OpenCode message parsing (#205)
- test: add P2 coverage improvements for CLI, handlers, plugins, and git-sync (#206)
- test: improve test coverage and reduce integration/E2E duplication (#204)
- fix(deps): resolve 5 high-severity Dependabot alerts (#210)
- docs: archive stale ADRs to reduce AI agent context noise
- docs: align ADRs, AGENTS.md, and architecture.md with current codebase
- chore: upgrade OpenCode CLI from v1.14.28 to v1.14.41
- chore: auto-sync ui/package.json version from Makefile VERSION

## Verification

- [x] `make verify` — generated code is up to date
- [x] `make test` — all unit tests pass
- [x] `make lint` — 0 issues
- [x] `go run -ldflags "-X main.Version=v0.1.3" ./cmd/kubeopencode version` — outputs `v0.1.3`
- [x] `helm template` — images tagged `v0.1.3`