### PR TITLE
chore: add worktree conventions to AGENTS.md and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # MacOS
 .DS_Store
 
+# Git worktrees
+.worktree/
+
 # Go
 bin/
 cover.out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 - **Always sign commits**: `git commit -s -m "feat: description"`
 - **PRs**: Check for upstream repos first; create PRs against upstream, not forks
 - **Releasing**: Follow `docs/releasing.md` (Release SOP) step-by-step. Never skip steps or improvise the release process.
+- **Git worktrees**: When developing with worktrees, create them under `.worktree/` in the project root (e.g., `git worktree add .worktree/<branch-name> <branch>`). The `.worktree/` directory is in `.gitignore`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Add `.worktree/` to `.gitignore` so git worktree directories are excluded from version control
- Document worktree convention in AGENTS.md: worktrees should be created under `.worktree/` in the project root (e.g., `git worktree add .worktree/<branch-name> <branch>`)