### PR TITLE
chore: bump opencode version to 1.15.0

### DIFF
--- a/agents/Makefile
+++ b/agents/Makefile
@@ -11,8 +11,8 @@ AGENT ?= devbox
 NO_CACHE ?=
 NO_CACHE_FLAG := $(if $(NO_CACHE),--no-cache,)
 
-# OpenCode version for opencode agent (usage: make AGENT=opencode OPENCODE_VERSION=1.3.13 build)
-OPENCODE_VERSION ?= 1.14.41
+# OpenCode version for opencode agent (usage: make AGENT=opencode OPENCODE_VERSION=1.15.0 build)
+OPENCODE_VERSION ?= 1.15.0
 
 # Image URL configuration
 IMG_REGISTRY ?= ghcr.io

--- a/agents/opencode/Dockerfile
+++ b/agents/opencode/Dockerfile
@@ -35,7 +35,7 @@
 #   OPENCODE_VERSION is defined in agents/Makefile (single source of truth).
 #   When building via make, it is passed automatically as --build-arg.
 #   For standalone docker build, you must pass it explicitly:
-#     docker build --build-arg OPENCODE_VERSION=1.14.19 -t opencode .
+#     docker build --build-arg OPENCODE_VERSION=1.15.0 -t opencode .
 #
 
 # Stage 1: download and verify the binary using glibc (Debian)


### PR DESCRIPTION
## Summary

- Update `OPENCODE_VERSION` from `1.14.41` to `1.15.0` in `agents/Makefile`
- Update version references in `agents/opencode/Dockerfile` comment (was stale at `1.14.19`)
- Update version in Makefile usage comment (was stale at `1.3.13`)