### PR TITLE
fix(ci): auto-fix Dependabot pnpm lockfile sync issues

### DIFF
--- a/.github/workflows/dependabot-fix.yaml
+++ b/.github/workflows/dependabot-fix.yaml
@@ -1,0 +1,32 @@
+# Copyright Contributors to the KubeOpenCode project
+name: Fix Dependabot Lockfile
+
+on:
+  pull_request:
+    paths:
+      - "website/pnpm-lock.yaml"
+
+jobs:
+  fix-lockfile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Re-sync lockfile
+        working-directory: website
+        run: pnpm install --no-frozen-lockfile
+
+      - uses: stefanzweifel/git-auto-commit-action@v6
+        with:
+          commit_message: "chore(deps): fix pnpm lockfile sync"


### PR DESCRIPTION
## Summary

Dependabot updates `pnpm-lock.yaml` specifier version ranges (e.g. `^3.0.0` → `^3.1.1`) without updating `package.json`, causing `pnpm install --frozen-lockfile` to fail with `ERR_PNPM_OUTDATED_LOCKFILE` on every Dependabot PR (e.g. #217).

This workflow automatically re-syncs the lockfile when Dependabot creates PRs that touch `website/pnpm-lock.yaml`, committing the fix back to the PR branch so subsequent CI checks pass.