### PR TITLE
fix: mark Task as Failed when OpenCode exits with application error

### DIFF
--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -23,8 +23,8 @@ const (
 	// This indicates the agent completed its work, not necessarily that the task "succeeded".
 	// The actual outcome should be determined by examining the agent's output.
 	TaskPhaseCompleted TaskPhase = "Completed"
-	// TaskPhaseFailed means the task had an infrastructure failure
-	// (e.g., Pod crashed, unable to schedule, missing Agent).
+	// TaskPhaseFailed means the task had a failure
+	// (e.g., Pod crashed, unable to schedule, missing Agent, or application error).
 	TaskPhaseFailed TaskPhase = "Failed"
 )
 

--- a/cmd/kubeopencode/task_submit.go
+++ b/cmd/kubeopencode/task_submit.go
@@ -88,8 +88,14 @@ func runTaskSubmit(cmd *cobra.Command, args []string) error {
 	fmt.Printf("[task-submit] session created: %s\n", sessionID)
 
 	// Step 2: Start SSE event streaming in background for logging
+	// Collect session errors from the event stream so we can report them
 	done := make(chan struct{})
-	go streamEvents(serverURL, sessionID, done)
+	streamDone := make(chan struct{})
+	sessionErrors := make(chan string, 16)
+	go func() {
+		streamEvents(serverURL, sessionID, done, sessionErrors)
+		close(streamDone)
+	}()
 
 	// Step 3: Submit the prompt
 	fmt.Println("[task-submit] submitting prompt...")
@@ -104,6 +110,27 @@ func runTaskSubmit(cmd *cobra.Command, args []string) error {
 	}
 
 	close(done)
+	// Wait for the SSE goroutine to finish so all errors are in the channel
+	<-streamDone
+
+	// Step 5: Check if any session errors occurred during execution.
+	// Session errors (e.g., ProviderModelNotFoundError) do not cause the status
+	// to become non-idle — the session transitions to "idle" after an error.
+	// We must check the error channel to detect these failures.
+	var errs []string
+collectErrors:
+	for {
+		select {
+		case e := <-sessionErrors:
+			errs = append(errs, e)
+		default:
+			break collectErrors
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("session completed with errors: %s", strings.Join(errs, "; "))
+	}
+
 	fmt.Println("[task-submit] session completed successfully")
 	return nil
 }
@@ -214,7 +241,8 @@ func waitForIdle(client *http.Client, serverURL, sessionID string) error {
 
 // streamEvents connects to the SSE endpoint and prints events for logging.
 // It does NOT handle permission.asked events — those are handled by the Web UI or TUI.
-func streamEvents(serverURL, sessionID string, done chan struct{}) {
+// Session errors are sent to sessionErrors channel for the caller to inspect after completion.
+func streamEvents(serverURL, sessionID string, done chan struct{}, sessionErrors chan<- string) {
 	// Use a client with no timeout for SSE
 	client := &http.Client{Timeout: 0}
 
@@ -280,6 +308,27 @@ func streamEvents(serverURL, sessionID string, done chan struct{}) {
 			if json.Unmarshal(event.Properties, &props) == nil && props.SessionID == sessionID {
 				fmt.Printf("\n[task-submit] WAITING FOR PERMISSION: %s (%s) — approve via Web UI or opencode attach\n",
 					props.Permission, strings.Join(props.Patterns, ", "))
+			}
+
+		case "session.error":
+			var props struct {
+				SessionID string `json:"sessionID"`
+				Error     struct {
+					Name    string `json:"name"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if json.Unmarshal(event.Properties, &props) == nil && props.SessionID == sessionID {
+				errMsg := props.Error.Name
+				if props.Error.Message != "" {
+					errMsg = props.Error.Message
+				}
+				if errMsg != "" {
+					select {
+					case sessionErrors <- errMsg:
+					default:
+					}
+				}
 			}
 
 		case "session.status":

--- a/cmd/kubeopencode/task_submit_test.go
+++ b/cmd/kubeopencode/task_submit_test.go
@@ -1,0 +1,456 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStreamEvents_SessionError(t *testing.T) {
+	sessionID := "test-session-123"
+
+	tests := []struct {
+		name       string
+		events     []string
+		wantErrors []string
+	}{
+		{
+			name: "collects session error with message",
+			events: []string{
+				sseEvent("session.error", map[string]interface{}{
+					"sessionID": sessionID,
+					"error": map[string]string{
+						"name":    "ProviderModelNotFoundError",
+						"message": "Model deepseek-v4-flash not found",
+					},
+				}),
+			},
+			wantErrors: []string{"Model deepseek-v4-flash not found"},
+		},
+		{
+			name: "collects session error with name only when message is empty",
+			events: []string{
+				sseEvent("session.error", map[string]interface{}{
+					"sessionID": sessionID,
+					"error": map[string]string{
+						"name":    "ProviderModelNotFoundError",
+						"message": "",
+					},
+				}),
+			},
+			wantErrors: []string{"ProviderModelNotFoundError"},
+		},
+		{
+			name: "collects multiple session errors",
+			events: []string{
+				sseEvent("session.error", map[string]interface{}{
+					"sessionID": sessionID,
+					"error": map[string]string{
+						"name":    "Error1",
+						"message": "First error",
+					},
+				}),
+				sseEvent("session.error", map[string]interface{}{
+					"sessionID": sessionID,
+					"error": map[string]string{
+						"name":    "Error2",
+						"message": "Second error",
+					},
+				}),
+			},
+			wantErrors: []string{"First error", "Second error"},
+		},
+		{
+			name: "ignores error for different session",
+			events: []string{
+				sseEvent("session.error", map[string]interface{}{
+					"sessionID": "other-session",
+					"error": map[string]string{
+						"name":    "SomeError",
+						"message": "Not our session",
+					},
+				}),
+			},
+			wantErrors: nil,
+		},
+		{
+			name: "ignores empty error name and message",
+			events: []string{
+				sseEvent("session.error", map[string]interface{}{
+					"sessionID": sessionID,
+					"error": map[string]string{
+						"name":    "",
+						"message": "",
+					},
+				}),
+			},
+			wantErrors: nil,
+		},
+		{
+			name: "prefers message over name when both present",
+			events: []string{
+				sseEvent("session.error", map[string]interface{}{
+					"sessionID": sessionID,
+					"error": map[string]string{
+						"name":    "ProviderModelNotFoundError",
+						"message": "Model not found",
+					},
+				}),
+			},
+			wantErrors: []string{"Model not found"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.Header().Set("Cache-Control", "no-cache")
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					t.Fatal("response writer must support flushing")
+				}
+
+				for _, event := range tt.events {
+					writeSSE(w, flusher, event)
+				}
+
+				writeSSE(w, flusher, fmt.Sprintf("data: {\"type\":\"session.status\",\"properties\":{\"sessionID\":\"%s\",\"status\":{\"type\":\"idle\"}}}\n\n", sessionID))
+			}))
+			defer server.Close()
+
+			done := make(chan struct{})
+			sessionErrors := make(chan string, 16)
+
+			go streamEvents(server.URL, sessionID, done, sessionErrors)
+
+			var gotErrors []string
+			timeout := time.After(5 * time.Second)
+		collect:
+			for {
+				select {
+				case e := <-sessionErrors:
+					gotErrors = append(gotErrors, e)
+				case <-timeout:
+					break collect
+				default:
+					if len(gotErrors) >= len(tt.wantErrors) {
+						break collect
+					}
+				}
+			}
+
+			if len(gotErrors) != len(tt.wantErrors) {
+				t.Fatalf("expected %d errors, got %d: %v", len(tt.wantErrors), len(gotErrors), gotErrors)
+			}
+			for i, want := range tt.wantErrors {
+				if gotErrors[i] != want {
+					t.Errorf("error[%d]: expected %q, got %q", i, want, gotErrors[i])
+				}
+			}
+
+			close(done)
+		})
+	}
+}
+
+func TestStreamEvents_DoneChannel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+
+		for i := 0; i < 100; i++ {
+			io.WriteString(w, "data: {\"type\":\"message.part.delta\",\"properties\":{\"sessionID\":\"s1\",\"part\":{\"type\":\"text\",\"text\":\"ping\"}}}\n\n")
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	done := make(chan struct{})
+	sessionErrors := make(chan string, 16)
+
+	doneCalled := make(chan struct{})
+	go func() {
+		streamEvents(server.URL, "s1", done, sessionErrors)
+		close(doneCalled)
+	}()
+
+	close(done)
+
+	select {
+	case <-doneCalled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("streamEvents did not return after done channel was closed")
+	}
+}
+
+func TestStreamEvents_ConnectionFailure(t *testing.T) {
+	done := make(chan struct{})
+	sessionErrors := make(chan string, 16)
+
+	defer close(done)
+
+	streamEvents("http://127.0.0.1:0/event", "s1", done, sessionErrors)
+
+	select {
+	case e := <-sessionErrors:
+		t.Errorf("expected no errors on connection failure, got: %s", e)
+	default:
+	}
+}
+
+func TestStreamEvents_PermissionAskedEvent(t *testing.T) {
+	sessionID := "test-session"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+
+		writeSSE(w, flusher, sseEvent("permission.asked", map[string]interface{}{
+			"sessionID":  sessionID,
+			"permission": "file-write",
+			"patterns":  []string{"/app/main.go"},
+		}))
+
+		writeSSE(w, flusher, fmt.Sprintf("data: {\"type\":\"session.status\",\"properties\":{\"sessionID\":\"%s\",\"status\":{\"type\":\"idle\"}}}\n\n", sessionID))
+	}))
+	defer server.Close()
+
+	done := make(chan struct{})
+	sessionErrors := make(chan string, 16)
+
+	go streamEvents(server.URL, sessionID, done, sessionErrors)
+
+	select {
+	case <-sessionErrors:
+		t.Error("permission.asked events should not produce errors")
+	case <-time.After(2 * time.Second):
+	}
+
+	close(done)
+}
+
+func TestStreamErrorsChannelFull(t *testing.T) {
+	sessionID := "test-session"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+
+		for i := 0; i < 20; i++ {
+			writeSSE(w, flusher, sseEvent("session.error", map[string]interface{}{
+				"sessionID": sessionID,
+				"error": map[string]string{
+					"name":    fmt.Sprintf("Error%d", i),
+					"message": fmt.Sprintf("Error message %d", i),
+				},
+			}))
+		}
+
+		writeSSE(w, flusher, fmt.Sprintf("data: {\"type\":\"session.status\",\"properties\":{\"sessionID\":\"%s\",\"status\":{\"type\":\"idle\"}}}\n\n", sessionID))
+	}))
+	defer server.Close()
+
+	done := make(chan struct{})
+	sessionErrors := make(chan string, 16)
+
+	go streamEvents(server.URL, sessionID, done, sessionErrors)
+
+	var collected []string
+	timeout := time.After(5 * time.Second)
+	waitMore := time.After(500 * time.Millisecond)
+loop:
+	for {
+		select {
+		case e := <-sessionErrors:
+			collected = append(collected, e)
+		case <-waitMore:
+			break loop
+		case <-timeout:
+			break loop
+		}
+	}
+
+	if len(collected) != 20 {
+		t.Errorf("expected 20 errors, got %d: %v", len(collected), collected)
+	}
+
+	close(done)
+}
+
+func TestStreamEvents_InvalidJSON(t *testing.T) {
+	sessionID := "test-session"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+
+		io.WriteString(w, "data: {invalid json}\n\n")
+		flusher.Flush()
+
+		writeSSE(w, flusher, sseEvent("session.error", map[string]interface{}{
+			"sessionID": sessionID,
+			"error": map[string]string{
+				"name":    "RealError",
+				"message": "This should still work",
+			},
+		}))
+
+		writeSSE(w, flusher, fmt.Sprintf("data: {\"type\":\"session.status\",\"properties\":{\"sessionID\":\"%s\",\"status\":{\"type\":\"idle\"}}}\n\n", sessionID))
+	}))
+	defer server.Close()
+
+	done := make(chan struct{})
+	sessionErrors := make(chan string, 16)
+
+	go streamEvents(server.URL, sessionID, done, sessionErrors)
+
+	var gotErrors []string
+	timeout := time.After(5 * time.Second)
+	waitMore := time.After(500 * time.Millisecond)
+loop:
+	for {
+		select {
+		case e := <-sessionErrors:
+			gotErrors = append(gotErrors, e)
+		case <-waitMore:
+			break loop
+		case <-timeout:
+			break loop
+		}
+	}
+
+	if len(gotErrors) != 1 {
+		t.Fatalf("expected exactly 1 error (invalid JSON should be skipped), got %d: %v", len(gotErrors), gotErrors)
+	}
+	if gotErrors[0] != "This should still work" {
+		t.Errorf("expected error message 'This should still work', got %q", gotErrors[0])
+	}
+
+	close(done)
+}
+
+func TestStreamEvents_SessionStatusIdle(t *testing.T) {
+	sessionID := "test-session"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+
+		writeSSE(w, flusher, sseEvent("session.error", map[string]interface{}{
+			"sessionID": sessionID,
+			"error": map[string]string{
+				"name":    "TestError",
+				"message": "Error before idle",
+			},
+		}))
+
+		writeSSE(w, flusher, fmt.Sprintf("data: {\"type\":\"session.status\",\"properties\":{\"sessionID\":\"%s\",\"status\":{\"type\":\"idle\"}}}\n\n", sessionID))
+	}))
+	defer server.Close()
+
+	done := make(chan struct{})
+	sessionErrors := make(chan string, 16)
+
+	streamFinished := make(chan struct{})
+	go func() {
+		streamEvents(server.URL, sessionID, done, sessionErrors)
+		close(streamFinished)
+	}()
+
+	select {
+	case <-streamFinished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("streamEvents did not return after receiving session.status idle")
+	}
+
+	var gotErrors []string
+	select {
+	case e := <-sessionErrors:
+		gotErrors = append(gotErrors, e)
+	default:
+	}
+
+	if len(gotErrors) != 1 || gotErrors[0] != "Error before idle" {
+		t.Errorf("expected 'Error before idle', got %v", gotErrors)
+	}
+
+	close(done)
+}
+
+func TestStreamEvents_NonDataLinesSkipped(t *testing.T) {
+	sessionID := "test-session"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+
+		io.WriteString(w, ": this is a comment\n")
+		io.WriteString(w, "event: custom\n")
+		io.WriteString(w, "id: 123\n")
+		io.WriteString(w, "retry: 5000\n\n")
+		flusher.Flush()
+
+		writeSSE(w, flusher, sseEvent("session.error", map[string]interface{}{
+			"sessionID": sessionID,
+			"error": map[string]string{
+				"name":    "AfterComments",
+				"message": "Error after non-data lines",
+			},
+		}))
+
+		writeSSE(w, flusher, fmt.Sprintf("data: {\"type\":\"session.status\",\"properties\":{\"sessionID\":\"%s\",\"status\":{\"type\":\"idle\"}}}\n\n", sessionID))
+	}))
+	defer server.Close()
+
+	done := make(chan struct{})
+	sessionErrors := make(chan string, 16)
+
+	streamFinished := make(chan struct{})
+	go func() {
+		streamEvents(server.URL, sessionID, done, sessionErrors)
+		close(streamFinished)
+	}()
+
+	select {
+	case <-streamFinished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("streamEvents did not return")
+	}
+
+	var gotErrors []string
+	select {
+	case e := <-sessionErrors:
+		gotErrors = append(gotErrors, e)
+	default:
+	}
+
+	if len(gotErrors) != 1 || !strings.Contains(gotErrors[0], "Error after non-data lines") {
+		t.Errorf("expected error after non-data lines, got %v", gotErrors)
+	}
+
+	close(done)
+}
+
+
+
+func sseEvent(eventType string, properties interface{}) string {
+	propsJSON, _ := json.Marshal(properties)
+	data, _ := json.Marshal(map[string]interface{}{
+		"type":       eventType,
+		"properties": json.RawMessage(propsJSON),
+	})
+	return "data: " + string(data)
+}
+
+func writeSSE(w io.Writer, flusher http.Flusher, data string) {
+	io.WriteString(w, data+"\n")
+	flusher.Flush()
+}

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -637,8 +637,16 @@ func (r *TaskReconciler) updateTaskStatusFromPod(ctx context.Context, task *kube
 		task.Status.Phase = kubeopenv1alpha1.TaskPhaseFailed
 		now := metav1.Now()
 		task.Status.CompletionTime = &now
-		log.Info("task failed", "pod", task.Status.PodName)
-		r.Recorder.Eventf(task, nil, corev1.EventTypeWarning, "Failed", "Failed", "Task failed")
+
+		// Extract container failure details for better diagnostics
+		failureDetail := getPodFailureDetail(pod)
+		if failureDetail != "" {
+			log.Info("task failed", "pod", task.Status.PodName, "detail", failureDetail)
+			r.Recorder.Eventf(task, nil, corev1.EventTypeWarning, "Failed", "Failed", "Task failed: %s", failureDetail)
+		} else {
+			log.Info("task failed", "pod", task.Status.PodName)
+			r.Recorder.Eventf(task, nil, corev1.EventTypeWarning, "Failed", "Failed", "Task failed")
+		}
 		r.recordTaskDuration(task)
 		// Resolve session info from Agent's OpenCode server (best-effort)
 		r.resolveSessionInfo(ctx, task)
@@ -646,6 +654,43 @@ func (r *TaskReconciler) updateTaskStatusFromPod(ctx context.Context, task *kube
 	}
 
 	return nil
+}
+
+// getPodFailureDetail extracts a human-readable failure reason from a failed Pod.
+// It inspects init container and container termination states to find the first
+// non-zero exit code or OOM/Signal reason.
+func getPodFailureDetail(pod *corev1.Pod) string {
+	// Check init containers first (they run before the main container)
+	for i := range pod.Status.InitContainerStatuses {
+		term := pod.Status.InitContainerStatuses[i].State.Terminated
+		if term != nil && term.ExitCode != 0 {
+			return formatTerminationDetail(pod.Status.InitContainerStatuses[i].Name, term)
+		}
+	}
+	// Check main containers
+	for i := range pod.Status.ContainerStatuses {
+		term := pod.Status.ContainerStatuses[i].State.Terminated
+		if term != nil && term.ExitCode != 0 {
+			return formatTerminationDetail(pod.Status.ContainerStatuses[i].Name, term)
+		}
+	}
+	return ""
+}
+
+// formatTerminationDetail creates a human-readable string from a container termination state.
+func formatTerminationDetail(containerName string, term *corev1.ContainerStateTerminated) string {
+	switch {
+	case term.Reason == "OOMKilled":
+		return fmt.Sprintf("container %s: OOMKilled", containerName)
+	case term.ExitCode != 0 && term.Message != "":
+		return fmt.Sprintf("container %s: exit code %d (%s: %s)", containerName, term.ExitCode, term.Reason, term.Message)
+	case term.ExitCode != 0:
+		return fmt.Sprintf("container %s: exit code %d (%s)", containerName, term.ExitCode, term.Reason)
+	case term.Message != "":
+		return fmt.Sprintf("container %s: %s", containerName, term.Message)
+	default:
+		return fmt.Sprintf("container %s: %s", containerName, term.Reason)
+	}
 }
 
 // resolveSessionInfo queries the Agent's OpenCode server to find the session

--- a/internal/controller/task_unit_test.go
+++ b/internal/controller/task_unit_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kubeopenv1alpha1 "github.com/kubeopencode/kubeopencode/api/v1alpha1"
@@ -206,6 +207,137 @@ func TestIsTaskTimedOut(t *testing.T) {
 		}
 		if !isTaskTimedOut(task) {
 			t.Error("expected true when timeout is zero (immediately expires)")
+		}
+	})
+}
+
+func TestGetPodFailureDetail(t *testing.T) {
+
+	t.Run("empty when all containers succeeded", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "agent",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 0,
+								Reason:   "Completed",
+							},
+						},
+					},
+				},
+			},
+		}
+		detail := getPodFailureDetail(pod)
+		if detail != "" {
+			t.Errorf("expected empty detail, got %q", detail)
+		}
+	})
+
+	t.Run("returns detail for main container failure", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "agent",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+								Reason:   "Error",
+								Message:  "Model not found",
+							},
+						},
+					},
+				},
+			},
+		}
+		detail := getPodFailureDetail(pod)
+		if detail == "" {
+			t.Error("expected non-empty detail")
+		}
+		if detail != "container agent: exit code 1 (Error: Model not found)" {
+			t.Errorf("unexpected detail: %q", detail)
+		}
+	})
+
+	t.Run("returns detail for init container failure", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "git-init-0",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 128,
+								Reason:   "Error",
+							},
+						},
+					},
+				},
+			},
+		}
+		detail := getPodFailureDetail(pod)
+		if detail == "" {
+			t.Error("expected non-empty detail")
+		}
+		if detail != "container git-init-0: exit code 128 (Error)" {
+			t.Errorf("unexpected detail: %q", detail)
+		}
+	})
+
+	t.Run("returns OOMKilled detail", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "agent",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 137,
+								Reason:   "OOMKilled",
+							},
+						},
+					},
+				},
+			},
+		}
+		detail := getPodFailureDetail(pod)
+		if detail != "container agent: OOMKilled" {
+			t.Errorf("unexpected detail: %q", detail)
+		}
+	})
+
+	t.Run("prioritizes init container failure over main container", func(t *testing.T) {
+		pod := &corev1.Pod{
+			Status: corev1.PodStatus{
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "git-init-0",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+								Reason:   "Error",
+							},
+						},
+					},
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "agent",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								ExitCode: 1,
+								Reason:   "Error",
+							},
+						},
+					},
+				},
+			},
+		}
+		detail := getPodFailureDetail(pod)
+		if detail != "container git-init-0: exit code 1 (Error)" {
+			t.Errorf("unexpected detail: %q", detail)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Tasks with application-level errors (e.g., `ProviderModelNotFoundError` for a nonexistent model like `deepseek-v4-flash`) were incorrectly marked as **Completed** instead of **Failed**. This happened because `task-submit` didn't track `session.error` SSE events from the OpenCode server, and the controller didn't extract container failure details for diagnostics.

## Changes

### `cmd/kubeopencode/task_submit.go`
- Added `sessionErrors` channel to `streamEvents` to collect `session.error` events from the SSE stream
- Wait for the SSE goroutine to finish (`<-streamDone`) before draining errors, avoiding a race condition
- Return error if any session errors occurred, causing `task-submit` to exit non-zero → Pod `Failed` → Task `Failed`

### `internal/controller/task_controller.go`
- Added `getPodFailureDetail()` and `formatTerminationDetail()` helpers to extract container termination info (exit code, reason, message, OOMKilled) from failed Pods
- Failure detail is now included in Task Failed events and log messages (e.g., `Task failed: container agent: exit code 1 (Error: Model not found)`)

### `api/v1alpha1/task_types.go`
- Updated `TaskPhaseFailed` doc comment to cover application errors, not just infrastructure failures

### `internal/controller/task_unit_test.go`
- Added 5 unit tests for `getPodFailureDetail`: success (empty), main container failure, init container failure, OOMKilled, init container priority

## How it works

1. `task-submit` connects to OpenCode server's SSE endpoint and listens for `session.error` events
2. When an error like ProviderModelNotFoundError occurs, OpenCode server already sends the event
3. `task-submit` detects the error and exits with non-zero code
4. Kubernetes marks the Pod as `Failed`
5. KubeOpenCode controller sees `PodFailed` → sets Task `Phase=Failed` with diagnostic details in the event message

## Testing

- Unit tests pass (`go test ./internal/controller/`)
- `go vet` and `golangci-lint` pass (only pre-existing issues in `git_init.go`)