### PR TITLE
fix: pre-warm models cache before opencode run in Task Pods

### DIFF
--- a/internal/controller/pod_builder.go
+++ b/internal/controller/pod_builder.go
@@ -269,6 +269,14 @@ const (
 	// Uses "|| true" to gracefully handle read-only root filesystems.
 	OpenCodeSymlinkCmd = "ln -sf /tools/opencode /usr/local/bin/opencode 2>/dev/null || true"
 
+	// OpenCodeModelsWarmupCmd pre-warms the OpenCode models cache before running a task.
+	// On cold starts (no persistent disk cache), "opencode run" may fail with
+	// ProviderModelNotFoundError because the models catalog hasn't been loaded yet.
+	// Running "opencode models --refresh" first ensures the cache is populated.
+	// Uses "|| true" to gracefully handle cases where the model warmup fails
+	// (e.g. network issues) without blocking task execution.
+	OpenCodeModelsWarmupCmd = "/tools/opencode models --refresh 2>/dev/null || true"
+
 	// PluginsVolumeName is the name of the emptyDir volume for installed plugins.
 	PluginsVolumeName = "plugins-volume"
 
@@ -1348,10 +1356,12 @@ func buildPod(task *kubeopenv1alpha1.Task, podName string, cfg agentConfig, cont
 				fmt.Sprintf(`%s; /tools/opencode run --attach %s --title %s "$(cat %s/task.md)"`, OpenCodeSymlinkCmd, serverURL, shellEscape(sessionTitle), cfg.workspaceDir),
 			}
 		} else {
-			// templateRef path: run standalone OpenCode instance
+			// templateRef path: run standalone OpenCode instance.
+			// Pre-warm the models cache to avoid ProviderModelNotFoundError on cold starts
+			// where no persistent disk cache exists (each Task Pod starts fresh).
 			agentCommand = []string{
 				"sh", "-c",
-				fmt.Sprintf(`%s; /tools/opencode run --title %s "$(cat %s/task.md)"`, OpenCodeSymlinkCmd, shellEscape(sessionTitle), cfg.workspaceDir),
+				fmt.Sprintf(`%s; %s; /tools/opencode run --title %s "$(cat %s/task.md)"`, OpenCodeSymlinkCmd, OpenCodeModelsWarmupCmd, shellEscape(sessionTitle), cfg.workspaceDir),
 			}
 		}
 	}

--- a/internal/controller/pod_builder_test.go
+++ b/internal/controller/pod_builder_test.go
@@ -1866,6 +1866,10 @@ func TestBuildPod_TemplateRef_WithoutAttachCommand(t *testing.T) {
 	if !strings.Contains(container.Command[2], "/tools/opencode run") {
 		t.Errorf("Command should use /tools/opencode run")
 	}
+	// Verify the command includes models warmup for templateRef (non-attach) path
+	if !strings.Contains(container.Command[2], "opencode models --refresh") {
+		t.Errorf("Command should include models warmup step for templateRef path, got: %s", container.Command[2])
+	}
 	// Verify the command includes --title with task name prefix
 	if !strings.Contains(container.Command[2], "--title") {
 		t.Errorf("Command should contain --title flag")


### PR DESCRIPTION
## Summary

- Add `opencode models --refresh` warmup step before `opencode run` in Task Pod commands (templateRef/standalone path only)
- On cold starts without persistent disk cache, `opencode run` fails with `ProviderModelNotFoundError` because the models catalog hasn't been populated yet

## Problem

Task Pods (templateRef path) start fresh every time with no PVC-backed cache. OpenCode loads models via: disk cache → snapshot → network fetch. Without any cache, if both snapshot and network fetch fail (e.g. proxy issues in cluster), the entire `opencode-go` provider ends up with zero models and gets deleted, causing `ProviderModelNotFoundError` with `suggestions: []`.

Agent Pods (serve mode) work fine because they have a persistent PVC with `/tmp/.cache/opencode/models.json` (1.9MB) that survives restarts.

## Changes

- New constant `OpenCodeModelsWarmupCmd`: `/tools/opencode models --refresh 2>/dev/null || true`
- TemplateRef (standalone) path command: `symlink; models --refresh; opencode run ...`
- AgentRef (--attach) path: unchanged (connects to already-initialized server)
- Custom command path: unchanged (user controls the command)
- Added test assertion for warmup step in `TestBuildPod_TemplateRef_WithoutAttachCommand`

## Test Plan

- [x] `go test ./internal/controller/` passes
- [ ] Deploy to local dev cluster and create a Task via templateRef, verify warmup step appears in pod command and models are pre-loaded