### PR TITLE
chore: release v0.1.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,7 +382,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.1.4
+- **Version**: v0.1.5
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= v0.1.4
+VERSION ?= v0.1.5
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.15.5
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= v0.1.4
+VERSION ?= v0.1.5
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.1.4
-appVersion: "v0.1.4"
+version: 0.1.5
+appVersion: "v0.1.5"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Release v0.1.5

### Changes since v0.1.4

**New Features:**
- CronTask maxRetained limit and delete task (#224)

**Bug Fixes:**
- Fix 6 Dependabot vulnerabilities in website dependencies (#232)
- Auto-sync ui/package.json version in release workflow

**Refactoring:**
- Extract probe timeout/failure constants (#229)
- Rename agentConfig variable to agentCfg to avoid shadowing (#234)
- Extract quota retry count to named constant (#225)
- Extract "Ready" condition type constant (#223)

**Dependencies:**
- Bump opencode version to 1.15.5 (#228)
- Bump stefanzweifel/git-auto-commit-action from 6 to 7 (#226)
- Bump webpack-dev-server from 5.2.3 to 5.2.4 in /ui (#230)

**Documentation:**
- Audit and fix documentation across docs/ and website/docs/ (#227)

### Version Updates
- Makefile VERSION: v0.1.4 → v0.1.5
- agents/Makefile VERSION: v0.1.4 → v0.1.5
- Chart.yaml version: 0.1.4 → 0.1.5, appVersion: v0.1.4 → v0.1.5
- AGENTS.md project status: v0.1.4 → v0.1.5