### PR TITLE
fix: add `/tools` volume mount to `context-init` in task pods when skills or plugins are configured

### DIFF
--- a/internal/controller/pod_builder.go
+++ b/internal/controller/pod_builder.go
@@ -1403,7 +1403,7 @@ func buildPod(task *kubeopenv1alpha1.Task, podName string, cfg agentConfig, cont
 		// If OpenCode config is provided, mount /tools volume in context-init
 		// so it can write the config file. The /tools volume is already created
 		// for sharing the OpenCode binary between containers.
-		if !configIsEmpty(cfg.config) {
+		if !configIsEmpty(cfg.config) || len(cfg.skills) > 0 || hasServerPlugins(cfg.plugins) {
 			contextInit.VolumeMounts = append(contextInit.VolumeMounts, corev1.VolumeMount{
 				Name:      ToolsVolumeName,
 				MountPath: ToolsMountPath,


### PR DESCRIPTION
When an Agent specifies `.spec.skills` or `.spec.plugins`, the controller injects the configuration into `opencode.json` and stores it in a ConfigMap. The `context-init` init container copies this file to `/tools/opencode.json` via `FILE_MAPPINGS`. However, the `/tools` volume mount was only added to `context-init` when inline config (`.spec.config`) was present — not when skills or plugins alone were configured.

This was previously fixed for Agent Deployments in `server_builder.go` (PR #193), but the same fix was missed for Task Pods in `pod_builder.go`.                                                                

Without the `/tools` volume mount, `context-init` cannot write `opencode.json`, the agent container starts with `OPENCODE_CONFIG=/tools/opencode.json` pointing to a  non-existent file, and `opencode run --attach` fails with `Error: Session not found`.