### PR TITLE
fix(agents): add pnpm to devbox image

### DIFF
--- a/agents/devbox/Dockerfile
+++ b/agents/devbox/Dockerfile
@@ -102,6 +102,9 @@ RUN for i in $(seq 1 $RETRY_COUNT); do \
       && break || { echo "Retry $i/$RETRY_COUNT failed, waiting ${RETRY_DELAY}s..."; sleep $RETRY_DELAY; }; \
     done
 
+# === pnpm ===
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
 # === Python 3 + pipx ===
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \


### PR DESCRIPTION
## Problem

The `fix-vulnerabilities` CronTask fails when executed in Kubernetes because the devbox executor image does not have `pnpm` installed. The `weekly-fix-vulnerabilities.md` workflow requires `pnpm why` and `pnpm install` to fix npm vulnerabilities via overrides.

## Fix

Install `pnpm` via `corepack` after Node.js setup in the devbox Dockerfile.

```dockerfile
RUN corepack enable && corepack prepare pnpm@latest --activate
```

## Verification

- Manual execution of the workflow works because the host has pnpm installed.
- This fix ensures the CronTask (running inside the devbox Pod) can also execute pnpm commands.
