### PR TITLE
chore: release v0.1.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,10 +382,10 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.1.6
+- **Version**: v0.1.7
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 
 ---
 
-**Last Updated**: 2026-05-08
+**Last Updated**: 2026-06-07

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= v0.1.6
+VERSION ?= v0.1.7
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.15.13
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= v0.1.6
+VERSION ?= v0.1.7
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.1.6
-appVersion: "v0.1.6"
+version: 0.1.7
+appVersion: "v0.1.7"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
Prepare v0.1.7 release.

- Update VERSION to v0.1.7 in Makefile and agents/Makefile
- Update Chart.yaml version and appVersion to match v0.1.7
- Update AGENTS.md project status version