### PR TITLE
chore(dependabot): filter npm scans to production dependencies only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    # Only scan production dependencies; devDependencies (vitest, webpack-dev-server, etc.)
+    # are false positives since they never enter the production bundle
+    allow:
+      - dependency-type: "production"
     groups:
       ui-dependencies:
         patterns:
@@ -49,6 +53,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    # Only scan production dependencies; website is a standalone docs site
+    # and its devDependencies do not affect the KubeOpenCode runtime
+    allow:
+      - dependency-type: "production"
     groups:
       website-dependencies:
         patterns:

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  qs: '>=6.15.2'
+
 importers:
 
   .:
@@ -2264,8 +2267,8 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -3966,7 +3969,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -4359,7 +4362,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -5141,7 +5144,7 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qs@6.14.2:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - '.'
+overrides:
+  qs: '>=6.15.2'


### PR DESCRIPTION
## Summary

This PR addresses the flood of false-positive Dependabot security alerts after PR #253.

### Problem

- PR #250 fixed Dependabot vulnerabilities (vitest, qs) via `pnpm.overrides` in `ui/package.json`.
- PR #253 removed the `pnpm.overrides` block while unifying the package manager to pnpm, causing `qs` to regress from 6.15.2 → 6.14.2.
- PR #253 also added `/ui` and `/website` to `.github/dependabot.yml`, expanding Dependabot scan coverage.
- As a result, Dependabot now reports many alerts from **devDependencies** (vitest, webpack-dev-server → express → qs, etc.) that **never enter the production bundle**.

### Changes

1. **`.github/dependabot.yml`** — Add `allow: dependency-type: production` to the `ui/` and `website/` npm ecosystems. This prevents Dependabot from creating alerts and PRs for devDependencies.
2. **`ui/pnpm-workspace.yaml`** — Restore the `qs >= 6.15.2` override. pnpm v11 no longer reads `pnpm.overrides` from `package.json`, so it must live in `pnpm-workspace.yaml`.
3. **`ui/pnpm-lock.yaml`** — Update `qs` from 6.14.2 → 6.15.2.

### Notes

- Existing false-positive alerts already in the Security tab will need to be manually dismissed after this merges.
- Go, Docker, GitHub Actions, and Helm ecosystems are unchanged.