### PR TITLE
chore: release v0.1.8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,7 +382,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.1.7
+- **Version**: v0.1.8
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: Apache License 2.0
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= v0.1.7
+VERSION ?= v0.1.8
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.17.11
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= v0.1.7
+VERSION ?= v0.1.8
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.1.7
-appVersion: "v0.1.7"
+version: 0.1.8
+appVersion: "v0.1.8"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
## Release v0.1.8

### Changes
- Update VERSION to v0.1.8 in Makefile and agents/Makefile
- Update Chart.yaml version and appVersion to match v0.1.8
- Update AGENTS.md project status version

### Recent changes since v0.1.7
- feat: support OpenCode config from ConfigMap via configMapRef
- fix: replace XValidation with runtime validation for config/configMapRef mutual exclusivity
- fix: replace XValidation with runtime validation, refactor configMapRef to configRef union type
- chore(deps): Bump debian in /agents/devbox (#273)
- chore(deps): Bump debian in /agents/opencode (#272)