### PR TITLE
fix: add podSpec.annotations and preserve user gitconfig (#280, #284)

### DIFF
--- a/api/v1alpha1/agent_types.go
+++ b/api/v1alpha1/agent_types.go
@@ -776,6 +776,26 @@ type AgentPodSpec struct {
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 
+	// Annotations defines additional annotations to add to the agent pod template.
+	// These annotations are applied to the Pod template (and, for Agents, the
+	// Deployment's pod template) alongside controller-managed annotations.
+	//
+	// Unlike labels, annotations are not used for selection, but they ARE included
+	// in the Deployment's pod template spec, so changing them triggers a new
+	// ReplicaSet and rolling update. This makes them suitable for:
+	//   - Hashing ConfigMap/Secret contents to force rollouts when mounted
+	//     configuration changes (e.g., checksum/config: <sha256>)
+	//   - Integrating with tooling that reads pod annotations (e.g., vault-agent
+	//     injection, Istio, Datadog)
+	//   - Arbitrary non-identifying metadata
+	//
+	// Example — roll pods when a mounted ConfigMap changes:
+	//   annotations:
+	//     checksum/config: <sha256-of-configmap-data>
+	//
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// Scheduling defines pod scheduling configuration for agent pods.
 	// This includes node selection, tolerations, and affinity rules.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -81,6 +81,13 @@ func (in *AgentPodSpec) DeepCopyInto(out *AgentPodSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Scheduling != nil {
 		in, out := &in.Scheduling, &out.Scheduling
 		*out = new(PodScheduling)

--- a/charts/kubeopencode/crds/kubeopencode.io_agents.yaml
+++ b/charts/kubeopencode/crds/kubeopencode.io_agents.yaml
@@ -758,6 +758,27 @@ spec:
                   This includes labels, scheduling, runtime class, and other Pod-level settings.
                   Use this for fine-grained control over how agent pods are created.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations defines additional annotations to add to the agent pod template.
+                      These annotations are applied to the Pod template (and, for Agents, the
+                      Deployment's pod template) alongside controller-managed annotations.
+
+                      Unlike labels, annotations are not used for selection, but they ARE included
+                      in the Deployment's pod template spec, so changing them triggers a new
+                      ReplicaSet and rolling update. This makes them suitable for:
+                        - Hashing ConfigMap/Secret contents to force rollouts when mounted
+                          configuration changes (e.g., checksum/config: <sha256>)
+                        - Integrating with tooling that reads pod annotations (e.g., vault-agent
+                          injection, Istio, Datadog)
+                        - Arbitrary non-identifying metadata
+
+                      Example — roll pods when a mounted ConfigMap changes:
+                        annotations:
+                          checksum/config: <sha256-of-configmap-data>
+                    type: object
                   extraEnv:
                     description: |-
                       ExtraEnv defines additional environment variables injected into ALL containers

--- a/charts/kubeopencode/crds/kubeopencode.io_agenttemplates.yaml
+++ b/charts/kubeopencode/crds/kubeopencode.io_agenttemplates.yaml
@@ -596,6 +596,27 @@ spec:
                 description: PodSpec defines advanced Pod configuration for agent
                   pods.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations defines additional annotations to add to the agent pod template.
+                      These annotations are applied to the Pod template (and, for Agents, the
+                      Deployment's pod template) alongside controller-managed annotations.
+
+                      Unlike labels, annotations are not used for selection, but they ARE included
+                      in the Deployment's pod template spec, so changing them triggers a new
+                      ReplicaSet and rolling update. This makes them suitable for:
+                        - Hashing ConfigMap/Secret contents to force rollouts when mounted
+                          configuration changes (e.g., checksum/config: <sha256>)
+                        - Integrating with tooling that reads pod annotations (e.g., vault-agent
+                          injection, Istio, Datadog)
+                        - Arbitrary non-identifying metadata
+
+                      Example — roll pods when a mounted ConfigMap changes:
+                        annotations:
+                          checksum/config: <sha256-of-configmap-data>
+                    type: object
                   extraEnv:
                     description: |-
                       ExtraEnv defines additional environment variables injected into ALL containers

--- a/deploy/crds/kubeopencode.io_agents.yaml
+++ b/deploy/crds/kubeopencode.io_agents.yaml
@@ -758,6 +758,27 @@ spec:
                   This includes labels, scheduling, runtime class, and other Pod-level settings.
                   Use this for fine-grained control over how agent pods are created.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations defines additional annotations to add to the agent pod template.
+                      These annotations are applied to the Pod template (and, for Agents, the
+                      Deployment's pod template) alongside controller-managed annotations.
+
+                      Unlike labels, annotations are not used for selection, but they ARE included
+                      in the Deployment's pod template spec, so changing them triggers a new
+                      ReplicaSet and rolling update. This makes them suitable for:
+                        - Hashing ConfigMap/Secret contents to force rollouts when mounted
+                          configuration changes (e.g., checksum/config: <sha256>)
+                        - Integrating with tooling that reads pod annotations (e.g., vault-agent
+                          injection, Istio, Datadog)
+                        - Arbitrary non-identifying metadata
+
+                      Example — roll pods when a mounted ConfigMap changes:
+                        annotations:
+                          checksum/config: <sha256-of-configmap-data>
+                    type: object
                   extraEnv:
                     description: |-
                       ExtraEnv defines additional environment variables injected into ALL containers

--- a/deploy/crds/kubeopencode.io_agenttemplates.yaml
+++ b/deploy/crds/kubeopencode.io_agenttemplates.yaml
@@ -596,6 +596,27 @@ spec:
                 description: PodSpec defines advanced Pod configuration for agent
                   pods.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations defines additional annotations to add to the agent pod template.
+                      These annotations are applied to the Pod template (and, for Agents, the
+                      Deployment's pod template) alongside controller-managed annotations.
+
+                      Unlike labels, annotations are not used for selection, but they ARE included
+                      in the Deployment's pod template spec, so changing them triggers a new
+                      ReplicaSet and rolling update. This makes them suitable for:
+                        - Hashing ConfigMap/Secret contents to force rollouts when mounted
+                          configuration changes (e.g., checksum/config: <sha256>)
+                        - Integrating with tooling that reads pod annotations (e.g., vault-agent
+                          injection, Istio, Datadog)
+                        - Arbitrary non-identifying metadata
+
+                      Example — roll pods when a mounted ConfigMap changes:
+                        annotations:
+                          checksum/config: <sha256-of-configmap-data>
+                    type: object
                   extraEnv:
                     description: |-
                       ExtraEnv defines additional environment variables injected into ALL containers

--- a/internal/controller/pod_builder.go
+++ b/internal/controller/pod_builder.go
@@ -479,6 +479,25 @@ func buildGitInitContainer(gm gitMount, volumeName string, index int, sysCfg sys
 	}
 }
 
+// gitSafeDirectoryEnvVars returns env vars that inject safe.directory=* into git's
+// config via GIT_CONFIG_COUNT without overriding the global config file path.
+//
+// This is used by the executor (worker) container when Git contexts are mounted:
+// init containers may clone repositories as a different UID than the executor
+// (common in OpenShift SCC / random-UID environments), so git would otherwise
+// refuse to operate on the repository with a "detected dubious ownership" error.
+//
+// Unlike setting GIT_CONFIG_GLOBAL, this approach adds safe.directory on top of
+// git's normal config resolution, so the user's ~/.gitconfig (user.name, aliases,
+// pull.rebase, etc.) is still respected. See issue #284.
+func gitSafeDirectoryEnvVars() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{Name: "GIT_CONFIG_COUNT", Value: "1"},
+		{Name: "GIT_CONFIG_KEY_0", Value: "safe.directory"},
+		{Name: "GIT_CONFIG_VALUE_0", Value: "*"},
+	}
+}
+
 // buildGitCredentialEnvVars returns env vars that reference a Secret for Git authentication.
 // The Secret can contain HTTPS credentials (username + password/PAT),
 // SSH credentials (ssh-privatekey + optional ssh-known-hosts), or both.
@@ -1557,22 +1576,18 @@ func buildPod(task *kubeopenv1alpha1.Task, podName string, cfg agentConfig, cont
 		})
 	}
 
-	// If we have Git mounts, add GIT_CONFIG_GLOBAL to point to shared gitconfig
-	// This is needed because init containers run as different users and git will
-	// refuse to work without safe.directory configured
+	// If we have Git mounts, inject safe.directory so git can operate on
+	// repositories cloned by init containers, which may run as different UIDs
+	// in SCC/random-UID environments.
+	//
+	// We use GIT_CONFIG_COUNT/GIT_CONFIG_KEY_*/GIT_CONFIG_VALUE* to add the
+	// safe.directory entry on top of git's normal config resolution. We
+	// intentionally do NOT set GIT_CONFIG_GLOBAL here: that would override the
+	// global config file path and silently hide the user's ~/.gitconfig (e.g.
+	// user.name, aliases, pull.rebase). Env-based injection preserves the
+	// user's global config while still granting safe.directory. See issue #284.
 	if len(gitMounts) > 0 {
-		// The first git-init container writes .gitconfig to /git/.gitconfig
-		// which is shared via git-context-0 volume
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  "GIT_CONFIG_GLOBAL",
-			Value: DefaultGitRoot + "/.gitconfig",
-		})
-		// Mount the git volume root to access the .gitconfig
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "git-context-0",
-			MountPath: DefaultGitRoot + "/.gitconfig",
-			SubPath:   ".gitconfig",
-		})
+		envVars = append(envVars, gitSafeDirectoryEnvVars()...)
 	}
 
 	// Add custom CA bundle to all containers if configured.
@@ -1629,6 +1644,18 @@ func buildPod(task *kubeopenv1alpha1.Task, podName string, cfg agentConfig, cont
 	if cfg.podSpec != nil {
 		for k, v := range cfg.podSpec.Labels {
 			podLabels[k] = v
+		}
+	}
+
+	// Build pod annotations from Agent.PodSpec.
+	// Task Pods have no controller-managed annotations, so user annotations are
+	// applied as-is. Including them in the pod template means changing them
+	// produces a new pod, which is useful for e.g. checksumming mounted ConfigMaps.
+	var podAnnotations map[string]string
+	if cfg.podSpec != nil && len(cfg.podSpec.Annotations) > 0 {
+		podAnnotations = make(map[string]string, len(cfg.podSpec.Annotations))
+		for k, v := range cfg.podSpec.Annotations {
+			podAnnotations[k] = v
 		}
 	}
 
@@ -1766,9 +1793,10 @@ func buildPod(task *kubeopenv1alpha1.Task, podName string, cfg agentConfig, cont
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: task.Namespace,
-			Labels:    podLabels,
+			Name:        podName,
+			Namespace:   task.Namespace,
+			Labels:      podLabels,
+			Annotations: podAnnotations,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(task, kubeopenv1alpha1.SchemeGroupVersion.WithKind("Task")),
 			},

--- a/internal/controller/pod_builder_test.go
+++ b/internal/controller/pod_builder_test.go
@@ -715,6 +715,77 @@ func TestBuildPod_WithPodScheduling(t *testing.T) {
 	}
 }
 
+// TestBuildPod_WithPodSpecAnnotations verifies that podSpec.annotations are
+// applied to the Task Pod's ObjectMeta. See issue #280.
+func TestBuildPod_WithPodSpecAnnotations(t *testing.T) {
+	task := &kubeopenv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       types.UID("test-uid"),
+		},
+	}
+	task.APIVersion = "kubeopencode.io/v1alpha1"
+	task.Kind = "Task"
+
+	cfg := agentConfig{
+		agentImage:         "test-opencode:v1.0.0",
+		executorImage:      "test-executor:v1.0.0",
+		workspaceDir:       "/workspace",
+		serviceAccountName: "test-sa",
+		podSpec: &kubeopenv1alpha1.AgentPodSpec{
+			Annotations: map[string]string{
+				"checksum/config": "abc123def456",
+				"owner":           "team-ai",
+			},
+		},
+	}
+
+	pod := buildPod(task, "test-task-pod", cfg, nil, nil, nil, nil, defaultSystemConfig(), "")
+
+	if pod.Annotations == nil {
+		t.Fatal("expected pod annotations, got nil")
+	}
+	if pod.Annotations["checksum/config"] != "abc123def456" {
+		t.Errorf("Pod.Annotations[checksum/config] = %q, want %q", pod.Annotations["checksum/config"], "abc123def456")
+	}
+	if pod.Annotations["owner"] != "team-ai" {
+		t.Errorf("Pod.Annotations[owner] = %q, want %q", pod.Annotations["owner"], "team-ai")
+	}
+
+	// Labels must remain unaffected by annotations
+	if pod.Labels["app"] != "kubeopencode" {
+		t.Errorf("Pod.Labels[app] = %q, want %q", pod.Labels["app"], "kubeopencode")
+	}
+}
+
+// TestBuildPod_WithoutPodSpecAnnotations verifies that pods have no annotations
+// when podSpec.annotations is not set.
+func TestBuildPod_WithoutPodSpecAnnotations(t *testing.T) {
+	task := &kubeopenv1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       types.UID("test-uid"),
+		},
+	}
+	task.APIVersion = "kubeopencode.io/v1alpha1"
+	task.Kind = "Task"
+
+	cfg := agentConfig{
+		agentImage:         "test-opencode:v1.0.0",
+		executorImage:      "test-executor:v1.0.0",
+		workspaceDir:       "/workspace",
+		serviceAccountName: "test-sa",
+	}
+
+	pod := buildPod(task, "test-task-pod", cfg, nil, nil, nil, nil, defaultSystemConfig(), "")
+
+	for k := range pod.Annotations {
+		t.Errorf("expected no pod annotations, found %q=%q", k, pod.Annotations[k])
+	}
+}
+
 func TestBuildPod_WithContextConfigMap(t *testing.T) {
 	task := &kubeopenv1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1001,6 +1072,30 @@ func TestBuildPod_WithGitMounts(t *testing.T) {
 	}
 	if !foundMount {
 		t.Errorf("Volume mount for /workspace/.claude not found")
+	}
+
+	// Verify safe.directory is injected via GIT_CONFIG_COUNT (not GIT_CONFIG_GLOBAL,
+	// which would mask the user's ~/.gitconfig). See issue #284.
+	execEnv := make(map[string]string)
+	for _, env := range container.Env {
+		execEnv[env.Name] = env.Value
+	}
+	if execEnv["GIT_CONFIG_GLOBAL"] != "" {
+		t.Errorf("GIT_CONFIG_GLOBAL should not be set on executor; got %q (it masks the user's global gitconfig)", execEnv["GIT_CONFIG_GLOBAL"])
+	}
+	if execEnv["GIT_CONFIG_COUNT"] != "1" {
+		t.Errorf("GIT_CONFIG_COUNT = %q, want %q", execEnv["GIT_CONFIG_COUNT"], "1")
+	}
+	if execEnv["GIT_CONFIG_KEY_0"] != "safe.directory" {
+		t.Errorf("GIT_CONFIG_KEY_0 = %q, want %q", execEnv["GIT_CONFIG_KEY_0"], "safe.directory")
+	}
+	if execEnv["GIT_CONFIG_VALUE_0"] != "*" {
+		t.Errorf("GIT_CONFIG_VALUE_0 = %q, want %q", execEnv["GIT_CONFIG_VALUE_0"], "*")
+	}
+	for _, vm := range container.VolumeMounts {
+		if vm.MountPath == DefaultGitRoot+"/.gitconfig" {
+			t.Errorf("executor should not mount managed .gitconfig; safe.directory is injected via env vars")
+		}
 	}
 }
 

--- a/internal/controller/server_builder.go
+++ b/internal/controller/server_builder.go
@@ -186,6 +186,16 @@ func BuildServerDeployment(agent *kubeopenv1alpha1.Agent, agentCfg agentConfig, 
 		maps.Copy(labels, agentCfg.podSpec.Labels)
 	}
 
+	// Build pod annotations: start with controller-managed annotations (e.g. git
+	// hash for rollout-trigger on sync) and merge user-provided annotations from
+	// podSpec on top. User annotations (such as a ConfigMap checksum) are included
+	// in the pod template, so changing them triggers a new ReplicaSet and rollout.
+	annotations := make(map[string]string, len(gitHashAnnotations))
+	maps.Copy(annotations, gitHashAnnotations)
+	if agentCfg.podSpec != nil && len(agentCfg.podSpec.Annotations) > 0 {
+		maps.Copy(annotations, agentCfg.podSpec.Annotations)
+	}
+
 	// Build environment variables
 	// HOME and SHELL are set for SCC (Security Context Constraints) compatibility.
 	// In SCC environments, containers run with random UIDs that have no /etc/passwd entry,
@@ -458,17 +468,12 @@ func BuildServerDeployment(agent *kubeopenv1alpha1.Agent, agentCfg agentConfig, 
 		})
 	}
 
-	// Add GIT_CONFIG_GLOBAL if we have Git mounts
+	// Inject safe.directory via GIT_CONFIG_COUNT if we have Git mounts.
+	// This lets git operate on repositories cloned by init containers that may
+	// run as different UIDs (SCC/random-UID environments). We avoid
+	// GIT_CONFIG_GLOBAL here so the user's ~/.gitconfig is not masked. See #284.
 	if len(ctxGitMounts) > 0 {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  "GIT_CONFIG_GLOBAL",
-			Value: DefaultGitRoot + "/.gitconfig",
-		})
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "git-context-0",
-			MountPath: DefaultGitRoot + "/.gitconfig",
-			SubPath:   ".gitconfig",
-		})
+		envVars = append(envVars, gitSafeDirectoryEnvVars()...)
 	}
 
 	// Check if context file is being mounted and inject OPENCODE_CONFIG_CONTENT
@@ -746,7 +751,7 @@ func BuildServerDeployment(agent *kubeopenv1alpha1.Agent, agentCfg agentConfig, 
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: gitHashAnnotations,
+					Annotations: annotations,
 				},
 				Spec: podSpec,
 			},

--- a/internal/controller/server_builder.go
+++ b/internal/controller/server_builder.go
@@ -186,13 +186,21 @@ func BuildServerDeployment(agent *kubeopenv1alpha1.Agent, agentCfg agentConfig, 
 		maps.Copy(labels, agentCfg.podSpec.Labels)
 	}
 
-	// Build pod annotations: start with controller-managed annotations (e.g. git
-	// hash for rollout-trigger on sync) and merge user-provided annotations from
-	// podSpec on top. User annotations (such as a ConfigMap checksum) are included
-	// in the pod template, so changing them triggers a new ReplicaSet and rollout.
-	annotations := make(map[string]string, len(gitHashAnnotations))
-	maps.Copy(annotations, gitHashAnnotations)
+	// Build pod annotations for the Deployment pod template.
+	//
+	// When the user does not set podSpec.annotations, preserve the controller-
+	// managed gitHashAnnotations as-is (which may be nil when there is no git
+	// sync and no context ConfigMap). This avoids flipping nil -> empty map {},
+	// which could needlessly churn the pod template on upgrade.
+	//
+	// When the user does set podSpec.annotations, merge them on top of the
+	// controller-managed annotations (user wins on key conflict). User
+	// annotations such as a ConfigMap checksum are part of the pod template, so
+	// changing them triggers a new ReplicaSet and rollout. See issue #280.
+	annotations := gitHashAnnotations
 	if agentCfg.podSpec != nil && len(agentCfg.podSpec.Annotations) > 0 {
+		annotations = make(map[string]string, len(gitHashAnnotations)+len(agentCfg.podSpec.Annotations))
+		maps.Copy(annotations, gitHashAnnotations)
 		maps.Copy(annotations, agentCfg.podSpec.Annotations)
 	}
 

--- a/internal/controller/server_builder_test.go
+++ b/internal/controller/server_builder_test.go
@@ -474,20 +474,31 @@ func TestBuildServerDeployment_WithGitContext(t *testing.T) {
 		t.Errorf("git-init-0 init container not found")
 	}
 
-	// Verify GIT_CONFIG_GLOBAL env var is set
+	// Verify safe.directory is injected via GIT_CONFIG_COUNT (not GIT_CONFIG_GLOBAL,
+	// which would mask the user's ~/.gitconfig). See issue #284.
 	container := deployment.Spec.Template.Spec.Containers[0]
-	var foundGitConfigGlobal bool
+	envMap := make(map[string]string)
 	for _, env := range container.Env {
-		if env.Name == "GIT_CONFIG_GLOBAL" {
-			foundGitConfigGlobal = true
-			expectedValue := DefaultGitRoot + "/.gitconfig"
-			if env.Value != expectedValue {
-				t.Errorf("GIT_CONFIG_GLOBAL = %q, want %q", env.Value, expectedValue)
-			}
-		}
+		envMap[env.Name] = env.Value
 	}
-	if !foundGitConfigGlobal {
-		t.Errorf("GIT_CONFIG_GLOBAL env var not found")
+	if envMap["GIT_CONFIG_GLOBAL"] != "" {
+		t.Errorf("GIT_CONFIG_GLOBAL should not be set; got %q (it masks the user's global gitconfig)", envMap["GIT_CONFIG_GLOBAL"])
+	}
+	if envMap["GIT_CONFIG_COUNT"] != "1" {
+		t.Errorf("GIT_CONFIG_COUNT = %q, want %q", envMap["GIT_CONFIG_COUNT"], "1")
+	}
+	if envMap["GIT_CONFIG_KEY_0"] != "safe.directory" {
+		t.Errorf("GIT_CONFIG_KEY_0 = %q, want %q", envMap["GIT_CONFIG_KEY_0"], "safe.directory")
+	}
+	if envMap["GIT_CONFIG_VALUE_0"] != "*" {
+		t.Errorf("GIT_CONFIG_VALUE_0 = %q, want %q", envMap["GIT_CONFIG_VALUE_0"], "*")
+	}
+
+	// Verify the executor no longer mounts the managed .gitconfig subPath.
+	for _, vm := range container.VolumeMounts {
+		if vm.MountPath == DefaultGitRoot+"/.gitconfig" {
+			t.Errorf("executor should not mount managed .gitconfig; safe.directory is injected via env vars")
+		}
 	}
 }
 
@@ -1672,6 +1683,98 @@ func TestBuildServerDeployment_WithGitSyncRollout(t *testing.T) {
 	}
 	if hash != "abc123def456" {
 		t.Errorf("expected hash 'abc123def456', got %q", hash)
+	}
+}
+
+// TestBuildServerDeployment_WithPodSpecAnnotations verifies that user-provided
+// podSpec.annotations are applied to the Deployment pod template and merged
+// with controller-managed (git-hash) annotations. See issue #280.
+func TestBuildServerDeployment_WithPodSpecAnnotations(t *testing.T) {
+	agent := &kubeopenv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "annot-agent",
+			Namespace: "default",
+		},
+		Spec: kubeopenv1alpha1.AgentSpec{Port: 4096},
+	}
+	cfg := agentConfig{
+		executorImage: "test-executor",
+		agentImage:    "test-agent",
+		workspaceDir:  "/workspace",
+		podSpec: &kubeopenv1alpha1.AgentPodSpec{
+			Annotations: map[string]string{
+				"checksum/config": "deadbeef",
+			},
+		},
+	}
+
+	gitMounts := []gitMount{
+		{
+			contextName:  "agent-config",
+			repository:   "https://github.com/org/config.git",
+			ref:          "main",
+			mountPath:    "/workspace/config",
+			depth:        1,
+			syncEnabled:  true,
+			syncPolicy:   kubeopenv1alpha1.GitSyncPolicyRollout,
+			syncInterval: 10 * time.Minute,
+		},
+	}
+	gitHashAnnotations := map[string]string{
+		"kubeopencode.io/git-hash-agent-config": "abc123def456",
+	}
+
+	deployment := BuildServerDeployment(agent, cfg, defaultSystemConfig(), nil, nil, nil, gitMounts, gitHashAnnotations)
+	if deployment == nil {
+		t.Fatal("BuildServerDeployment returned nil")
+	}
+
+	ann := deployment.Spec.Template.Annotations
+	if ann == nil {
+		t.Fatal("expected pod template annotations, got nil")
+	}
+	// Controller-managed annotation preserved
+	if ann["kubeopencode.io/git-hash-agent-config"] != "abc123def456" {
+		t.Errorf("git hash annotation = %q, want %q", ann["kubeopencode.io/git-hash-agent-config"], "abc123def456")
+	}
+	// User annotation present
+	if ann["checksum/config"] != "deadbeef" {
+		t.Errorf("user annotation checksum/config = %q, want %q", ann["checksum/config"], "deadbeef")
+	}
+}
+
+// TestBuildServerDeployment_PodSpecAnnotationsNoGitHash verifies user
+// annotations are applied even when there are no controller-managed annotations.
+func TestBuildServerDeployment_PodSpecAnnotationsNoGitHash(t *testing.T) {
+	agent := &kubeopenv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "annot-agent-2",
+			Namespace: "default",
+		},
+		Spec: kubeopenv1alpha1.AgentSpec{Port: 4096},
+	}
+	cfg := agentConfig{
+		executorImage: "test-executor",
+		agentImage:    "test-agent",
+		workspaceDir:  "/workspace",
+		podSpec: &kubeopenv1alpha1.AgentPodSpec{
+			Annotations: map[string]string{
+				"owner": "team-ai",
+			},
+		},
+	}
+
+	deployment := BuildServerDeployment(agent, cfg, defaultSystemConfig(), nil, nil, nil, nil, nil)
+	if deployment == nil {
+		t.Fatal("BuildServerDeployment returned nil")
+	}
+
+	ann := deployment.Spec.Template.Annotations
+	if ann == nil {
+		t.Fatal("expected pod template annotations, got nil")
+	}
+	if ann["owner"] != "team-ai" {
+		t.Errorf("user annotation owner = %q, want %q", ann["owner"], "team-ai")
 	}
 }
 

--- a/internal/controller/server_builder_test.go
+++ b/internal/controller/server_builder_test.go
@@ -1778,6 +1778,35 @@ func TestBuildServerDeployment_PodSpecAnnotationsNoGitHash(t *testing.T) {
 	}
 }
 
+// TestBuildServerDeployment_NoAnnotationsStaysNil verifies that when neither
+// controller-managed annotations nor user podSpec.annotations are provided, the
+// pod template Annotations stay nil (matching pre-#280 behavior) instead of
+// becoming an empty map, so the change does not needlessly churn the pod
+// template on upgrade.
+func TestBuildServerDeployment_NoAnnotationsStaysNil(t *testing.T) {
+	agent := &kubeopenv1alpha1.Agent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-annot-agent",
+			Namespace: "default",
+		},
+		Spec: kubeopenv1alpha1.AgentSpec{Port: 4096},
+	}
+	cfg := agentConfig{
+		executorImage: "test-executor",
+		agentImage:    "test-agent",
+		workspaceDir:  "/workspace",
+	}
+
+	deployment := BuildServerDeployment(agent, cfg, defaultSystemConfig(), nil, nil, nil, nil, nil)
+	if deployment == nil {
+		t.Fatal("BuildServerDeployment returned nil")
+	}
+
+	if deployment.Spec.Template.Annotations != nil {
+		t.Errorf("expected pod template Annotations to stay nil when no annotations are configured, got %v", deployment.Spec.Template.Annotations)
+	}
+}
+
 func TestHashConfigMapData(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Fixes #280 and #284 — two high-confidence, low-complexity issues from @verdverm. Verified each issue against the codebase before fixing; details below.

## #280 — Agent podSpec.annotations

**Problem:** `AgentPodSpec` only exposed `Labels`, with no `Annotations` field. Users could not set pod template annotations, blocking the common pattern of hashing a mounted ConfigMap's data into an annotation to trigger a Deployment rollout (labels have value length/charset limits and many toolchains expect annotations).

**Fix:** Add an `annotations` field to `AgentPodSpec` and apply it to:
- Task Pods (`pod_builder.go`) — written to `Pod.ObjectMeta.Annotations`
- Agent Deployments (`server_builder.go`) — merged with controller-managed git-hash annotations (user annotations win on key conflict)

## #284 — kubeopencode gitconfig hides custom gitconfig

**Problem:** When Git contexts were mounted, the executor set `GIT_CONFIG_GLOBAL=/git/.gitconfig`. `GIT_CONFIG_GLOBAL` **replaces** git's global config file path, so the user's `~/.gitconfig` (`user.name`, aliases, `pull.rebase`, etc.) was silently ignored. `podSpec.extraEnv` could not override it (append-only → duplicate env var → K8s rejects), so there was no clean way to combine.

**Fix:** Replace `GIT_CONFIG_GLOBAL` + the `.gitconfig` subPath mount with env-based config injection:
```
GIT_CONFIG_COUNT=1
GIT_CONFIG_KEY_0=safe.directory
GIT_CONFIG_VALUE_0=*
```
This adds the `safe.directory` entry (needed for random-UID / SCC environments where init containers and the executor run as different UIDs) **on top of** git's normal config resolution, instead of replacing the global config path. The user's `~/.gitconfig` is now respected.

Verified locally that with this approach:
- User's `~/.gitconfig` is read (`user.name`, `core.autoCRLF` preserved)
- `safe.directory=*` is injected
- `git status` succeeds on a dubious-ownership repo (chown'd to a different UID)

`git-init` is left unchanged: it never read `GIT_CONFIG_GLOBAL`, and neither does the `git-sync` sidecar, so the change is scoped to the executor container.

## Verification
- `make update-crds` + `make update-scripts` (regenerated CRDs + deepcopy)
- `make build` ✅
- `make test` ✅
- `make lint` ✅ (0 issues)
- `make verify` ✅
- Added unit tests covering both fixes (annotations on Task Pods + Deployments, with/without git-hash merge; GIT_CONFIG_COUNT injection + assert GIT_CONFIG_GLOBAL not set + no managed .gitconfig mount)

## Out of scope (other verdverm issues)
- #283 (tmux / shared shell) — architectural change, not a simple fix
- #282 (deep-merge podSpec across template/Agent) — changes merge semantics with breakage risk; deserves its own PR
- #281 (OPENCODE_CONFIG_DIR) — needs a new API field; larger scope