### PR TITLE
fix: deep-merge podSpec across Agent and AgentTemplate (#282)

### DIFF
--- a/internal/controller/template_merge.go
+++ b/internal/controller/template_merge.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -52,14 +53,18 @@ func ResolveAgentConfigFromTemplate(ctx context.Context, reader client.Reader, a
 // Agent-level fields take precedence over template values:
 //   - Scalar/pointer fields: Agent wins if non-zero/non-nil
 //   - List fields (contexts, credentials, imagePullSecrets): Agent replaces template if non-nil
+//   - podSpec: deep-merged field by field (see mergePodSpec). List/map fields are
+//     combined (template values first, Agent values appended and winning on name/key
+//     conflict); scalar pointer fields use Agent if non-nil, else template. This lets
+//     a template define common volumes/env/labels while an Agent extends them with
+//     instance-specific values. See issue #282.
 //
 // The returned agentConfig has image defaults applied (same as ResolveAgentConfig).
 func MergeAgentWithTemplate(agent *kubeopenv1alpha1.Agent, tmpl *kubeopenv1alpha1.AgentTemplate) agentConfig {
-	// podSpec is merged as a whole (Agent wins if non-nil). When Agent has a podSpec,
-	// its ExtraEnv and SystemContainers take precedence. When only the template has a
-	// podSpec, those values are inherited. This is consistent with all other list/pointer
-	// fields in the merge strategy.
-	mergedPodSpec := firstNonNilPtr(agent.Spec.PodSpec, tmpl.Spec.PodSpec)
+	// podSpec is deep-merged so a template can contribute common volumes/env/labels
+	// and the Agent can extend (not replace) them. When only one side defines a
+	// podSpec, it is used as-is. See issue #282.
+	mergedPodSpec := mergePodSpec(agent.Spec.PodSpec, tmpl.Spec.PodSpec)
 
 	merged := agentConfig{
 		agentImage:    defaultString(agent.Spec.AgentImage, defaultString(tmpl.Spec.AgentImage, DefaultAgentImage)),
@@ -121,4 +126,176 @@ func firstNonNilPtr[T any](a, b *T) *T {
 		return a
 	}
 	return b
+}
+
+// mergePodSpec deep-merges an Agent's podSpec with its template's podSpec.
+//
+// Merge strategy:
+//   - Labels, Annotations: maps are combined; Agent wins on key conflict.
+//   - Scheduling: NodeSelector maps are combined (Agent wins); Tolerations are
+//     appended (template first, then Agent); Affinity uses Agent if non-nil
+//     else template (deep-merging affinity is complex and rarely needed).
+//   - ExtraVolumes, ExtraVolumeMounts, ExtraEnv: slices are combined, deduped by
+//     Name with Agent winning on collision. This avoids generating pods that
+//     Kubernetes would reject for duplicate volume/env/mount names.
+//   - SystemContainers: each per-container-type override is deep-merged (ExtraEnv
+//     and ExtraVolumeMounts combined with Agent winning on Name collision).
+//   - Scalar pointer fields (RuntimeClassName, Resources, SecurityContext,
+//     PodSecurityContext, Lifecycle): Agent wins if non-nil, else template.
+//
+// When only one side is non-nil, it is returned as-is (no allocation). When both
+// are nil, nil is returned. See issue #282.
+func mergePodSpec(agentPS, tmplPS *kubeopenv1alpha1.AgentPodSpec) *kubeopenv1alpha1.AgentPodSpec {
+	if agentPS == nil {
+		return tmplPS
+	}
+	if tmplPS == nil {
+		return agentPS
+	}
+	return &kubeopenv1alpha1.AgentPodSpec{
+		Labels:             mergeStringMap(agentPS.Labels, tmplPS.Labels),
+		Annotations:        mergeStringMap(agentPS.Annotations, tmplPS.Annotations),
+		Scheduling:         mergeScheduling(agentPS.Scheduling, tmplPS.Scheduling),
+		RuntimeClassName:   firstNonNilPtr(agentPS.RuntimeClassName, tmplPS.RuntimeClassName),
+		Resources:          firstNonNilPtr(agentPS.Resources, tmplPS.Resources),
+		SecurityContext:    firstNonNilPtr(agentPS.SecurityContext, tmplPS.SecurityContext),
+		PodSecurityContext: firstNonNilPtr(agentPS.PodSecurityContext, tmplPS.PodSecurityContext),
+		Lifecycle:          firstNonNilPtr(agentPS.Lifecycle, tmplPS.Lifecycle),
+		ExtraVolumes:       mergeVolumes(agentPS.ExtraVolumes, tmplPS.ExtraVolumes),
+		ExtraVolumeMounts:  mergeVolumeMounts(agentPS.ExtraVolumeMounts, tmplPS.ExtraVolumeMounts),
+		ExtraEnv:           mergeEnvVars(agentPS.ExtraEnv, tmplPS.ExtraEnv),
+		SystemContainers:   mergeSystemContainers(agentPS.SystemContainers, tmplPS.SystemContainers),
+	}
+}
+
+// mergeStringMap combines two string maps. Agent (a) wins on key conflict.
+// Returns nil if both are empty.
+func mergeStringMap(a, b map[string]string) map[string]string {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	out := make(map[string]string, len(a)+len(b))
+	for k, v := range b {
+		out[k] = v
+	}
+	for k, v := range a {
+		out[k] = v
+	}
+	return out
+}
+
+// mergeNamedSlice combines two slices of named Kubernetes objects. Items from b
+// (template) come first, then items from a (agent). On Name collision, the agent
+// (a) value replaces the template (b) value. Items with an empty Name are always
+// appended. Returns nil if both are empty.
+func mergeNamedSlice[T any](a, b []T, nameOf func(T) string) []T {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	out := make([]T, 0, len(a)+len(b))
+	idxByName := make(map[string]int, len(a)+len(b))
+	add := func(item T, agentWins bool) {
+		n := nameOf(item)
+		if n == "" {
+			out = append(out, item)
+			return
+		}
+		if idx, ok := idxByName[n]; ok && agentWins {
+			out[idx] = item // agent wins over earlier (template) entry
+		} else if !ok {
+			out = append(out, item)
+			idxByName[n] = len(out) - 1
+		}
+		// If collision and !agentWins (a duplicate within template), keep the first.
+	}
+	for _, item := range b {
+		add(item, false)
+	}
+	for _, item := range a {
+		add(item, true)
+	}
+	return out
+}
+
+func mergeVolumes(a, b []corev1.Volume) []corev1.Volume {
+	return mergeNamedSlice(a, b, func(v corev1.Volume) string { return v.Name })
+}
+
+func mergeVolumeMounts(a, b []corev1.VolumeMount) []corev1.VolumeMount {
+	return mergeNamedSlice(a, b, func(vm corev1.VolumeMount) string { return vm.Name })
+}
+
+func mergeEnvVars(a, b []corev1.EnvVar) []corev1.EnvVar {
+	return mergeNamedSlice(a, b, func(e corev1.EnvVar) string { return e.Name })
+}
+
+// mergeScheduling deep-merges two PodScheduling pointers. Agent (a) wins for
+// scalar pointer fields; NodeSelector maps are combined (Agent wins); Tolerations
+// are appended (template first, then Agent).
+func mergeScheduling(a, b *kubeopenv1alpha1.PodScheduling) *kubeopenv1alpha1.PodScheduling {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	return &kubeopenv1alpha1.PodScheduling{
+		NodeSelector: mergeStringMap(a.NodeSelector, b.NodeSelector),
+		Tolerations:  mergeTolerations(a.Tolerations, b.Tolerations),
+		Affinity:     firstNonNilPtr(a.Affinity, b.Affinity),
+	}
+}
+
+// mergeTolerations appends agent tolerations after template tolerations.
+// Duplicate tolerations are harmless to Kubernetes, so no dedup is performed.
+func mergeTolerations(a, b []corev1.Toleration) []corev1.Toleration {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	out := make([]corev1.Toleration, 0, len(a)+len(b))
+	out = append(out, b...)
+	out = append(out, a...)
+	return out
+}
+
+// mergeSystemContainers deep-merges per-container-type overrides. Each
+// container-type override is merged independently; Agent (a) wins for nil-or-not.
+func mergeSystemContainers(a, b *kubeopenv1alpha1.SystemContainerOverrides) *kubeopenv1alpha1.SystemContainerOverrides {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	return &kubeopenv1alpha1.SystemContainerOverrides{
+		OpenCodeInit: mergeInitContainerOverrides(a.OpenCodeInit, b.OpenCodeInit),
+		ContextInit:  mergeInitContainerOverrides(a.ContextInit, b.ContextInit),
+		GitInit:      mergeInitContainerOverrides(a.GitInit, b.GitInit),
+		GitSync:      mergeInitContainerOverrides(a.GitSync, b.GitSync),
+		PluginInit:   mergeInitContainerOverrides(a.PluginInit, b.PluginInit),
+	}
+}
+
+// mergeInitContainerOverrides combines ExtraEnv and ExtraVolumeMounts from both
+// overrides, deduped by Name with Agent (a) winning on collision.
+func mergeInitContainerOverrides(a, b *kubeopenv1alpha1.InitContainerOverrides) *kubeopenv1alpha1.InitContainerOverrides {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	return &kubeopenv1alpha1.InitContainerOverrides{
+		ExtraEnv:          mergeEnvVars(a.ExtraEnv, b.ExtraEnv),
+		ExtraVolumeMounts: mergeVolumeMounts(a.ExtraVolumeMounts, b.ExtraVolumeMounts),
+	}
 }

--- a/internal/controller/template_merge_test.go
+++ b/internal/controller/template_merge_test.go
@@ -1107,12 +1107,289 @@ func TestMergePodSpec_ScalarPointersInheritTemplateWhenAgentNil(t *testing.T) {
 	}
 }
 
+// --- More merge edge-case tests (nil branches, all systemContainer types) ---
+
+func TestMergePodSpec_SchedulingAgentNilInheritsTemplate(t *testing.T) {
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		Scheduling: &kubeopenv1alpha1.PodScheduling{NodeSelector: map[string]string{"t": "v"}},
+	}
+	agent := &kubeopenv1alpha1.AgentPodSpec{Labels: map[string]string{"a": "b"}}
+	got := mergePodSpec(agent, tmpl)
+	if got.Scheduling == nil || got.Scheduling.NodeSelector["t"] != "v" {
+		t.Errorf("expected template Scheduling inherited when Agent's is nil, got %v", got.Scheduling)
+	}
+}
+
+func TestMergePodSpec_SchedulingTemplateNilUsesAgent(t *testing.T) {
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		Scheduling: &kubeopenv1alpha1.PodScheduling{NodeSelector: map[string]string{"a": "v"}},
+	}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{Labels: map[string]string{"t": "b"}}
+	got := mergePodSpec(agent, tmpl)
+	if got.Scheduling == nil || got.Scheduling.NodeSelector["a"] != "v" {
+		t.Errorf("expected agent Scheduling used when template's is nil, got %v", got.Scheduling)
+	}
+}
+
+func TestMergePodSpec_TolerationsOneSideEmpty(t *testing.T) {
+	// Agent Tolerations empty -> inherit template's
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		Scheduling: &kubeopenv1alpha1.PodScheduling{Tolerations: nil},
+	}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		Scheduling: &kubeopenv1alpha1.PodScheduling{
+			Tolerations: []corev1.Toleration{{Key: "k1", Effect: corev1.TaintEffectNoSchedule}},
+		},
+	}
+	got := mergePodSpec(agent, tmpl)
+	if len(got.Scheduling.Tolerations) != 1 || got.Scheduling.Tolerations[0].Key != "k1" {
+		t.Errorf("expected template tolerations inherited, got %v", got.Scheduling.Tolerations)
+	}
+
+	// Template Tolerations empty -> use agent's
+	agent2 := &kubeopenv1alpha1.AgentPodSpec{
+		Scheduling: &kubeopenv1alpha1.PodScheduling{
+			Tolerations: []corev1.Toleration{{Key: "k2", Effect: corev1.TaintEffectNoSchedule}},
+		},
+	}
+	tmpl2 := &kubeopenv1alpha1.AgentPodSpec{
+		Scheduling: &kubeopenv1alpha1.PodScheduling{Tolerations: nil},
+	}
+	got2 := mergePodSpec(agent2, tmpl2)
+	if len(got2.Scheduling.Tolerations) != 1 || got2.Scheduling.Tolerations[0].Key != "k2" {
+		t.Errorf("expected agent tolerations used, got %v", got2.Scheduling.Tolerations)
+	}
+}
+
+func TestMergePodSpec_SystemContainersAllTypesAndVolumeMountsMerged(t *testing.T) {
+	mkSC := func(prefix string) *kubeopenv1alpha1.SystemContainerOverrides {
+		return &kubeopenv1alpha1.SystemContainerOverrides{
+			OpenCodeInit: &kubeopenv1alpha1.InitContainerOverrides{
+				ExtraEnv:          []corev1.EnvVar{{Name: prefix + "-oci-env"}},
+				ExtraVolumeMounts: []corev1.VolumeMount{{Name: prefix + "-oci-vm", MountPath: "/" + prefix + "-oci"}},
+			},
+			ContextInit: &kubeopenv1alpha1.InitContainerOverrides{
+				ExtraEnv:          []corev1.EnvVar{{Name: prefix + "-ci-env"}},
+				ExtraVolumeMounts: []corev1.VolumeMount{{Name: prefix + "-ci-vm", MountPath: "/" + prefix + "-ci"}},
+			},
+			GitInit: &kubeopenv1alpha1.InitContainerOverrides{
+				ExtraEnv:          []corev1.EnvVar{{Name: prefix + "-gi-env"}},
+				ExtraVolumeMounts: []corev1.VolumeMount{{Name: prefix + "-gi-vm", MountPath: "/" + prefix + "-gi"}},
+			},
+			GitSync: &kubeopenv1alpha1.InitContainerOverrides{
+				ExtraEnv:          []corev1.EnvVar{{Name: prefix + "-gs-env"}},
+				ExtraVolumeMounts: []corev1.VolumeMount{{Name: prefix + "-gs-vm", MountPath: "/" + prefix + "-gs"}},
+			},
+			PluginInit: &kubeopenv1alpha1.InitContainerOverrides{
+				ExtraEnv:          []corev1.EnvVar{{Name: prefix + "-pi-env"}},
+				ExtraVolumeMounts: []corev1.VolumeMount{{Name: prefix + "-pi-vm", MountPath: "/" + prefix + "-pi"}},
+			},
+		}
+	}
+	agent := &kubeopenv1alpha1.AgentPodSpec{SystemContainers: mkSC("agent")}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{SystemContainers: mkSC("tmpl")}
+	got := mergePodSpec(agent, tmpl)
+
+	if got.SystemContainers == nil {
+		t.Fatal("expected merged systemContainers")
+	}
+	checks := []struct {
+		name string
+		abbr string
+		sc   *kubeopenv1alpha1.InitContainerOverrides
+	}{
+		{"OpenCodeInit", "oci", got.SystemContainers.OpenCodeInit},
+		{"ContextInit", "ci", got.SystemContainers.ContextInit},
+		{"GitInit", "gi", got.SystemContainers.GitInit},
+		{"GitSync", "gs", got.SystemContainers.GitSync},
+		{"PluginInit", "pi", got.SystemContainers.PluginInit},
+	}
+	for _, c := range checks {
+		if c.sc == nil {
+			t.Errorf("%s: expected non-nil override", c.name)
+			continue
+		}
+		envNames := envVarNames(c.sc.ExtraEnv)
+		if !sliceContains(envNames, "agent-"+c.abbr+"-env") {
+			t.Errorf("%s: agent env missing in %v", c.name, envNames)
+		}
+		if !sliceContains(envNames, "tmpl-"+c.abbr+"-env") {
+			t.Errorf("%s: template env missing (deep-merged) in %v", c.name, envNames)
+		}
+		vmNames := volumeMountNames(c.sc.ExtraVolumeMounts)
+		if !sliceContains(vmNames, "agent-"+c.abbr+"-vm") {
+			t.Errorf("%s: agent volume mount missing in %v", c.name, vmNames)
+		}
+		if !sliceContains(vmNames, "tmpl-"+c.abbr+"-vm") {
+			t.Errorf("%s: template volume mount missing (deep-merged) in %v", c.name, vmNames)
+		}
+	}
+}
+
+func TestMergePodSpec_SystemContainersOneSideNil(t *testing.T) {
+	tmplSC := &kubeopenv1alpha1.SystemContainerOverrides{
+		GitInit: &kubeopenv1alpha1.InitContainerOverrides{ExtraEnv: []corev1.EnvVar{{Name: "FROM_TMPL"}}},
+	}
+	// Agent SystemContainers nil -> inherit template's
+	agent := &kubeopenv1alpha1.AgentPodSpec{Labels: map[string]string{"a": "b"}}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{SystemContainers: tmplSC}
+	got := mergePodSpec(agent, tmpl)
+	if got.SystemContainers != tmplSC {
+		t.Errorf("expected template SystemContainers inherited when Agent's is nil, got %v", got.SystemContainers)
+	}
+
+	// Agent SystemContainers set, template nil -> use agent's
+	agentSC := &kubeopenv1alpha1.SystemContainerOverrides{
+		GitInit: &kubeopenv1alpha1.InitContainerOverrides{ExtraEnv: []corev1.EnvVar{{Name: "FROM_AGENT"}}},
+	}
+	agent2 := &kubeopenv1alpha1.AgentPodSpec{SystemContainers: agentSC}
+	tmpl2 := &kubeopenv1alpha1.AgentPodSpec{Labels: map[string]string{"t": "b"}}
+	got2 := mergePodSpec(agent2, tmpl2)
+	if got2.SystemContainers != agentSC {
+		t.Errorf("expected agent SystemContainers used when template's is nil, got %v", got2.SystemContainers)
+	}
+}
+
+func TestMergePodSpec_InitContainerOverrideOneSideNil(t *testing.T) {
+	// Agent defines GitInit only; template defines ContextInit only.
+	// Merged result should have both, each from the side that set it.
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		SystemContainers: &kubeopenv1alpha1.SystemContainerOverrides{
+			GitInit: &kubeopenv1alpha1.InitContainerOverrides{ExtraEnv: []corev1.EnvVar{{Name: "GIT_FROM_AGENT"}}},
+		},
+	}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		SystemContainers: &kubeopenv1alpha1.SystemContainerOverrides{
+			ContextInit: &kubeopenv1alpha1.InitContainerOverrides{ExtraEnv: []corev1.EnvVar{{Name: "CTX_FROM_TMPL"}}},
+		},
+	}
+	got := mergePodSpec(agent, tmpl)
+
+	if got.SystemContainers == nil {
+		t.Fatal("expected merged systemContainers")
+	}
+	if got.SystemContainers.GitInit == nil || len(envVarNames(got.SystemContainers.GitInit.ExtraEnv)) == 0 {
+		t.Errorf("expected GitInit from agent preserved, got %v", got.SystemContainers.GitInit)
+	}
+	if got.SystemContainers.ContextInit == nil || len(envVarNames(got.SystemContainers.ContextInit.ExtraEnv)) == 0 {
+		t.Errorf("expected ContextInit from template inherited, got %v", got.SystemContainers.ContextInit)
+	}
+	if got.SystemContainers.GitSync != nil || got.SystemContainers.PluginInit != nil || got.SystemContainers.OpenCodeInit != nil {
+		t.Errorf("unset container types should stay nil, got %v", got.SystemContainers)
+	}
+}
+
+func TestMergePodSpec_ScalarPointersInheritAllFromTemplate(t *testing.T) {
+	tmplRuntime := "kata"
+	tmplRes := corev1.ResourceRequirements{Limits: corev1.ResourceList{}}
+	tmplSC := &corev1.SecurityContext{Privileged: boolPtr(false)}
+	tmplPodSC := &corev1.PodSecurityContext{RunAsUser: int64Ptr(1000)}
+	tmplLifecycle := &corev1.Lifecycle{}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		RuntimeClassName:   &tmplRuntime,
+		Resources:          &tmplRes,
+		SecurityContext:    tmplSC,
+		PodSecurityContext: tmplPodSC,
+		Lifecycle:          tmplLifecycle,
+	}
+	// Agent has podSpec but all scalar pointers nil
+	agent := &kubeopenv1alpha1.AgentPodSpec{Labels: map[string]string{"a": "b"}}
+	got := mergePodSpec(agent, tmpl)
+
+	if got.RuntimeClassName == nil || *got.RuntimeClassName != "kata" {
+		t.Errorf("RuntimeClassName should inherit template, got %v", got.RuntimeClassName)
+	}
+	if got.Resources != &tmplRes {
+		t.Errorf("Resources should inherit template, got %v", got.Resources)
+	}
+	if got.SecurityContext != tmplSC {
+		t.Errorf("SecurityContext should inherit template, got %v", got.SecurityContext)
+	}
+	if got.PodSecurityContext != tmplPodSC {
+		t.Errorf("PodSecurityContext should inherit template, got %v", got.PodSecurityContext)
+	}
+	if got.Lifecycle != tmplLifecycle {
+		t.Errorf("Lifecycle should inherit template, got %v", got.Lifecycle)
+	}
+}
+
+func TestMergePodSpec_ExtraVolumesAgentOnlyWhenTemplateHasNone(t *testing.T) {
+	// Template podSpec is non-nil (has Labels) but no ExtraVolumes; Agent has
+	// ExtraVolumes. Covers mergeNamedSlice's len(b)==0 -> return a passthrough.
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		Labels:       map[string]string{"a": "b"},
+		ExtraVolumes: []corev1.Volume{{Name: "agent-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
+	}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{Labels: map[string]string{"t": "b"}}
+	got := mergePodSpec(agent, tmpl)
+	names := volumeNames(got.ExtraVolumes)
+	if len(names) != 1 || names[0] != "agent-vol" {
+		t.Errorf("expected only agent-vol, got %v", names)
+	}
+}
+
+func TestMergeNamedSlice_EmptyNameAppended(t *testing.T) {
+	// Items with an empty Name are always appended (no dedup possible). This
+	// exercises the defensive empty-name branch.
+	a := []corev1.EnvVar{{Name: "", Value: "a-empty"}, {Name: "X", Value: "a-x"}}
+	b := []corev1.EnvVar{{Name: "", Value: "b-empty"}, {Name: "Y", Value: "b-y"}}
+	got := mergeEnvVars(a, b)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 env vars (no dedup for empty names), got %d: %v", len(got), got)
+	}
+	emptyCount := 0
+	for _, e := range got {
+		if e.Name == "" {
+			emptyCount++
+		}
+	}
+	if emptyCount != 2 {
+		t.Errorf("expected both empty-name entries preserved, got %d", emptyCount)
+	}
+}
+
+func TestMergeNamedSlice_WithinTemplateDuplicateKeepsFirst(t *testing.T) {
+	// Two template volumes share a name; the first must survive (agentWins=false
+	// collision branch). Agent has no collision.
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		ExtraVolumes: []corev1.Volume{
+			{Name: "dup", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumDefault}}},
+			{Name: "dup", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}}},
+		},
+	}
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		ExtraVolumes: []corev1.Volume{{Name: "agent-vol"}},
+	}
+	got := mergePodSpec(agent, tmpl)
+
+	count := 0
+	for _, v := range got.ExtraVolumes {
+		if v.Name == "dup" {
+			count++
+			if v.EmptyDir == nil || v.EmptyDir.Medium != corev1.StorageMediumDefault {
+				t.Errorf("first template 'dup' (Default medium) should be kept, got %v", v.EmptyDir)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 'dup' after dedup, got %d", count)
+	}
+}
+
 // --- helpers ---
 
 func volumeNames(vols []corev1.Volume) []string {
 	out := make([]string, 0, len(vols))
 	for _, v := range vols {
 		out = append(out, v.Name)
+	}
+	return out
+}
+
+func envVarNames(envs []corev1.EnvVar) []string {
+	out := make([]string, 0, len(envs))
+	for _, e := range envs {
+		out = append(out, e.Name)
 	}
 	return out
 }

--- a/internal/controller/template_merge_test.go
+++ b/internal/controller/template_merge_test.go
@@ -717,7 +717,10 @@ func TestResolveTemplateToConfig(t *testing.T) {
 
 // --- Tests for extraEnv / systemContainers merge behaviour ---
 
-func TestMergeAgentWithTemplate_ExtraEnv_AgentWins(t *testing.T) {
+// TestMergeAgentWithTemplate_ExtraEnv_DeepMerged verifies that podSpec.extraEnv
+// from the template and the Agent are combined (not replaced). Agent wins on
+// name collision. See issue #282.
+func TestMergeAgentWithTemplate_ExtraEnv_DeepMerged(t *testing.T) {
 	agent := &kubeopenv1alpha1.Agent{
 		Spec: kubeopenv1alpha1.AgentSpec{
 			WorkspaceDir:       "/workspace",
@@ -725,6 +728,7 @@ func TestMergeAgentWithTemplate_ExtraEnv_AgentWins(t *testing.T) {
 			PodSpec: &kubeopenv1alpha1.AgentPodSpec{
 				ExtraEnv: []corev1.EnvVar{
 					{Name: "FROM_AGENT", Value: "yes"},
+					{Name: "SHARED", Value: "agent-wins"},
 				},
 			},
 		},
@@ -736,6 +740,7 @@ func TestMergeAgentWithTemplate_ExtraEnv_AgentWins(t *testing.T) {
 			PodSpec: &kubeopenv1alpha1.AgentPodSpec{
 				ExtraEnv: []corev1.EnvVar{
 					{Name: "FROM_TEMPLATE", Value: "yes"},
+					{Name: "SHARED", Value: "template-value"},
 				},
 			},
 		},
@@ -743,18 +748,19 @@ func TestMergeAgentWithTemplate_ExtraEnv_AgentWins(t *testing.T) {
 
 	cfg := MergeAgentWithTemplate(agent, tmpl)
 
-	// Agent podSpec wins entirely — FROM_AGENT present, FROM_TEMPLATE absent
-	found := false
+	envMap := make(map[string]string)
 	for _, e := range cfg.extraEnv {
-		if e.Name == "FROM_AGENT" {
-			found = true
-		}
-		if e.Name == "FROM_TEMPLATE" {
-			t.Error("FROM_TEMPLATE should not be present when Agent has its own podSpec")
-		}
+		envMap[e.Name] = e.Value
 	}
-	if !found {
-		t.Error("expected FROM_AGENT in merged extraEnv")
+	if envMap["FROM_AGENT"] != "yes" {
+		t.Errorf("expected FROM_AGENT=yes in merged extraEnv, got %v", envMap["FROM_AGENT"])
+	}
+	if envMap["FROM_TEMPLATE"] != "yes" {
+		t.Errorf("expected FROM_TEMPLATE=yes (deep-merged, not replaced) in merged extraEnv, got %v", envMap["FROM_TEMPLATE"])
+	}
+	// Collision: Agent wins
+	if envMap["SHARED"] != "agent-wins" {
+		t.Errorf("expected SHARED=agent-wins (Agent wins on collision), got %v", envMap["SHARED"])
 	}
 }
 
@@ -812,7 +818,11 @@ func TestMergeAgentWithTemplate_ExtraEnv_TemplateInheritedWhenAgentHasNoPodSpec(
 	}
 }
 
-func TestMergeAgentWithTemplate_SystemContainers_AgentWins(t *testing.T) {
+// TestMergeAgentWithTemplate_SystemContainers_DeepMerged verifies that
+// podSpec.systemContainers per-container-type overrides are deep-merged between
+// template and Agent (ExtraEnv combined, Agent wins on name collision).
+// See issue #282.
+func TestMergeAgentWithTemplate_SystemContainers_DeepMerged(t *testing.T) {
 	agent := &kubeopenv1alpha1.Agent{
 		Spec: kubeopenv1alpha1.AgentSpec{
 			WorkspaceDir:       "/workspace",
@@ -820,7 +830,10 @@ func TestMergeAgentWithTemplate_SystemContainers_AgentWins(t *testing.T) {
 			PodSpec: &kubeopenv1alpha1.AgentPodSpec{
 				SystemContainers: &kubeopenv1alpha1.SystemContainerOverrides{
 					GitInit: &kubeopenv1alpha1.InitContainerOverrides{
-						ExtraEnv: []corev1.EnvVar{{Name: "FROM_AGENT_SC", Value: "agent"}},
+						ExtraEnv: []corev1.EnvVar{
+							{Name: "FROM_AGENT_SC", Value: "agent"},
+							{Name: "SHARED_SC", Value: "agent-wins"},
+						},
 					},
 				},
 			},
@@ -833,7 +846,10 @@ func TestMergeAgentWithTemplate_SystemContainers_AgentWins(t *testing.T) {
 			PodSpec: &kubeopenv1alpha1.AgentPodSpec{
 				SystemContainers: &kubeopenv1alpha1.SystemContainerOverrides{
 					GitInit: &kubeopenv1alpha1.InitContainerOverrides{
-						ExtraEnv: []corev1.EnvVar{{Name: "FROM_TMPL_SC", Value: "template"}},
+						ExtraEnv: []corev1.EnvVar{
+							{Name: "FROM_TMPL_SC", Value: "template"},
+							{Name: "SHARED_SC", Value: "template-value"},
+						},
 					},
 				},
 			},
@@ -843,18 +859,281 @@ func TestMergeAgentWithTemplate_SystemContainers_AgentWins(t *testing.T) {
 	cfg := MergeAgentWithTemplate(agent, tmpl)
 
 	if cfg.systemContainers == nil || cfg.systemContainers.GitInit == nil {
-		t.Fatal("expected systemContainers.GitInit from agent")
+		t.Fatal("expected systemContainers.GitInit to be set")
 	}
-	foundAgent := false
+	envMap := make(map[string]string)
 	for _, e := range cfg.systemContainers.GitInit.ExtraEnv {
-		if e.Name == "FROM_AGENT_SC" {
-			foundAgent = true
-		}
-		if e.Name == "FROM_TMPL_SC" {
-			t.Error("FROM_TMPL_SC should not be present when Agent has its own podSpec")
+		envMap[e.Name] = e.Value
+	}
+	if envMap["FROM_AGENT_SC"] != "agent" {
+		t.Errorf("expected FROM_AGENT_SC=agent, got %v", envMap["FROM_AGENT_SC"])
+	}
+	if envMap["FROM_TMPL_SC"] != "template" {
+		t.Errorf("expected FROM_TMPL_SC=template (deep-merged, not replaced), got %v", envMap["FROM_TMPL_SC"])
+	}
+	if envMap["SHARED_SC"] != "agent-wins" {
+		t.Errorf("expected SHARED_SC=agent-wins (Agent wins on collision), got %v", envMap["SHARED_SC"])
+	}
+}
+
+// --- Direct tests for mergePodSpec covering each field's merge strategy (#282) ---
+
+func TestMergePodSpec_BothNil(t *testing.T) {
+	if got := mergePodSpec(nil, nil); got != nil {
+		t.Errorf("mergePodSpec(nil, nil) = %v, want nil", got)
+	}
+}
+
+func TestMergePodSpec_AgentNilReturnsTemplate(t *testing.T) {
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{Labels: map[string]string{"a": "b"}}
+	got := mergePodSpec(nil, tmpl)
+	if got != tmpl {
+		t.Errorf("mergePodSpec(nil, tmpl) should return template as-is, got %v", got)
+	}
+}
+
+func TestMergePodSpec_TemplateNilReturnsAgent(t *testing.T) {
+	agent := &kubeopenv1alpha1.AgentPodSpec{Labels: map[string]string{"a": "b"}}
+	got := mergePodSpec(agent, nil)
+	if got != agent {
+		t.Errorf("mergePodSpec(agent, nil) should return agent as-is, got %v", got)
+	}
+}
+
+func TestMergePodSpec_LabelsAndAnnotationsMerged(t *testing.T) {
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		Labels:      map[string]string{"agent-only": "a", "shared": "agent"},
+		Annotations: map[string]string{"agent-only-ann": "a", "shared-ann": "agent"},
+	}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		Labels:      map[string]string{"tmpl-only": "t", "shared": "template"},
+		Annotations: map[string]string{"tmpl-only-ann": "t", "shared-ann": "template"},
+	}
+	got := mergePodSpec(agent, tmpl)
+
+	if got.Labels["agent-only"] != "a" {
+		t.Errorf("agent-only label lost: %v", got.Labels)
+	}
+	if got.Labels["tmpl-only"] != "t" {
+		t.Errorf("tmpl-only label lost: %v", got.Labels)
+	}
+	if got.Labels["shared"] != "agent" {
+		t.Errorf("shared label should be agent (Agent wins), got %v", got.Labels["shared"])
+	}
+	if got.Annotations["agent-only-ann"] != "a" {
+		t.Errorf("agent-only annotation lost: %v", got.Annotations)
+	}
+	if got.Annotations["tmpl-only-ann"] != "t" {
+		t.Errorf("tmpl-only annotation lost: %v", got.Annotations)
+	}
+	if got.Annotations["shared-ann"] != "agent" {
+		t.Errorf("shared annotation should be agent (Agent wins), got %v", got.Annotations["shared-ann"])
+	}
+}
+
+func TestMergePodSpec_ExtraVolumesDedupByName(t *testing.T) {
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		ExtraVolumes: []corev1.Volume{
+			{Name: "agent-vol"},
+			{Name: "shared-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}}},
+		},
+	}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		ExtraVolumes: []corev1.Volume{
+			{Name: "tmpl-vol"},
+			{Name: "shared-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumDefault}}},
+		},
+	}
+	got := mergePodSpec(agent, tmpl)
+
+	names := volumeNames(got.ExtraVolumes)
+	if !sliceContains(names, "agent-vol") || !sliceContains(names, "tmpl-vol") {
+		t.Errorf("expected both agent-vol and tmpl-vol, got %v", names)
+	}
+	// Exactly one shared-vol, and it must be the Agent's (Memory medium)
+	count := 0
+	for _, v := range got.ExtraVolumes {
+		if v.Name == "shared-vol" {
+			count++
+			if v.EmptyDir == nil || v.EmptyDir.Medium != corev1.StorageMediumMemory {
+				t.Errorf("shared-vol should be Agent's (Memory), got %v", v.EmptyDir)
+			}
 		}
 	}
-	if !foundAgent {
-		t.Error("expected FROM_AGENT_SC in merged systemContainers.GitInit.ExtraEnv")
+	if count != 1 {
+		t.Errorf("expected exactly 1 shared-vol after dedup, got %d", count)
 	}
+}
+
+func TestMergePodSpec_ExtraVolumeMountsDedupByName(t *testing.T) {
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		ExtraVolumeMounts: []corev1.VolumeMount{
+			{Name: "agent-mount", MountPath: "/agent"},
+			{Name: "shared-mount", MountPath: "/agent-path"},
+		},
+	}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		ExtraVolumeMounts: []corev1.VolumeMount{
+			{Name: "tmpl-mount", MountPath: "/tmpl"},
+			{Name: "shared-mount", MountPath: "/tmpl-path"},
+		},
+	}
+	got := mergePodSpec(agent, tmpl)
+
+	names := volumeMountNames(got.ExtraVolumeMounts)
+	if !sliceContains(names, "agent-mount") || !sliceContains(names, "tmpl-mount") {
+		t.Errorf("expected both agent-mount and tmpl-mount, got %v", names)
+	}
+	count := 0
+	for _, vm := range got.ExtraVolumeMounts {
+		if vm.Name == "shared-mount" {
+			count++
+			if vm.MountPath != "/agent-path" {
+				t.Errorf("shared-mount should be Agent's path, got %s", vm.MountPath)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 shared-mount after dedup, got %d", count)
+	}
+}
+
+func TestMergePodSpec_SchedulingMerged(t *testing.T) {
+	agentAffinity := &corev1.Affinity{NodeAffinity: &corev1.NodeAffinity{}}
+	tmplAffinity := &corev1.Affinity{PodAffinity: &corev1.PodAffinity{}}
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		Scheduling: &kubeopenv1alpha1.PodScheduling{
+			NodeSelector: map[string]string{"agent-only": "a", "shared": "agent"},
+			Tolerations:  []corev1.Toleration{{Key: "agent-taint", Effect: corev1.TaintEffectNoSchedule}},
+			Affinity:     agentAffinity,
+		},
+	}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		Scheduling: &kubeopenv1alpha1.PodScheduling{
+			NodeSelector: map[string]string{"tmpl-only": "t", "shared": "template"},
+			Tolerations:  []corev1.Toleration{{Key: "tmpl-taint", Effect: corev1.TaintEffectNoSchedule}},
+			Affinity:     tmplAffinity,
+		},
+	}
+	got := mergePodSpec(agent, tmpl)
+
+	if got.Scheduling == nil {
+		t.Fatal("expected merged scheduling")
+	}
+	if got.Scheduling.NodeSelector["agent-only"] != "a" || got.Scheduling.NodeSelector["tmpl-only"] != "t" {
+		t.Errorf("NodeSelector not merged: %v", got.Scheduling.NodeSelector)
+	}
+	if got.Scheduling.NodeSelector["shared"] != "agent" {
+		t.Errorf("NodeSelector shared should be agent (Agent wins): %v", got.Scheduling.NodeSelector["shared"])
+	}
+	if len(got.Scheduling.Tolerations) != 2 {
+		t.Errorf("expected 2 tolerations (appended), got %d: %v", len(got.Scheduling.Tolerations), got.Scheduling.Tolerations)
+	}
+	if got.Scheduling.Affinity != agentAffinity {
+		t.Errorf("Affinity should be Agent's (firstNonNilPtr), got %v", got.Scheduling.Affinity)
+	}
+}
+
+func TestMergePodSpec_SchedulingTemplateAffinityWhenAgentNil(t *testing.T) {
+	tmplAffinity := &corev1.Affinity{PodAffinity: &corev1.PodAffinity{}}
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		Scheduling: &kubeopenv1alpha1.PodScheduling{NodeSelector: map[string]string{"a": "b"}},
+	}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		Scheduling: &kubeopenv1alpha1.PodScheduling{Affinity: tmplAffinity},
+	}
+	got := mergePodSpec(agent, tmpl)
+	if got.Scheduling.Affinity != tmplAffinity {
+		t.Errorf("Affinity should be template's when Agent's is nil, got %v", got.Scheduling.Affinity)
+	}
+}
+
+func TestMergePodSpec_ScalarPointersAgentWins(t *testing.T) {
+	agentRuntime := "gvisor"
+	agentRes := corev1.ResourceRequirements{Limits: corev1.ResourceList{}}
+	agentSC := &corev1.SecurityContext{Privileged: boolPtr(true)}
+	agentPodSC := &corev1.PodSecurityContext{RunAsUser: int64Ptr(1000)}
+	agentLifecycle := &corev1.Lifecycle{}
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		RuntimeClassName:   &agentRuntime,
+		Resources:          &agentRes,
+		SecurityContext:    agentSC,
+		PodSecurityContext: agentPodSC,
+		Lifecycle:          agentLifecycle,
+	}
+	tmplRuntime := "kata"
+	tmplRes := corev1.ResourceRequirements{}
+	tmplSC := &corev1.SecurityContext{Privileged: boolPtr(false)}
+	tmplPodSC := &corev1.PodSecurityContext{RunAsUser: int64Ptr(0)}
+	tmplLifecycle := &corev1.Lifecycle{}
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		RuntimeClassName:   &tmplRuntime,
+		Resources:          &tmplRes,
+		SecurityContext:    tmplSC,
+		PodSecurityContext: tmplPodSC,
+		Lifecycle:          tmplLifecycle,
+	}
+	got := mergePodSpec(agent, tmpl)
+
+	if got.RuntimeClassName == nil || *got.RuntimeClassName != "gvisor" {
+		t.Errorf("RuntimeClassName should be Agent's gvisor, got %v", got.RuntimeClassName)
+	}
+	if got.SecurityContext != agentSC {
+		t.Errorf("SecurityContext should be Agent's, got %v", got.SecurityContext)
+	}
+	if got.PodSecurityContext != agentPodSC {
+		t.Errorf("PodSecurityContext should be Agent's, got %v", got.PodSecurityContext)
+	}
+	if got.Lifecycle != agentLifecycle {
+		t.Errorf("Lifecycle should be Agent's, got %v", got.Lifecycle)
+	}
+	if got.Resources == nil || got.Resources != &agentRes {
+		t.Errorf("Resources should be Agent's, got %v", got.Resources)
+	}
+}
+
+func TestMergePodSpec_ScalarPointersInheritTemplateWhenAgentNil(t *testing.T) {
+	tmplRuntime := "kata"
+	tmpl := &kubeopenv1alpha1.AgentPodSpec{
+		RuntimeClassName: &tmplRuntime,
+	}
+	agent := &kubeopenv1alpha1.AgentPodSpec{
+		// RuntimeClassName nil
+		Labels: map[string]string{"a": "b"},
+	}
+	got := mergePodSpec(agent, tmpl)
+	if got.RuntimeClassName == nil || *got.RuntimeClassName != "kata" {
+		t.Errorf("RuntimeClassName should be template's kata, got %v", got.RuntimeClassName)
+	}
+}
+
+// --- helpers ---
+
+func volumeNames(vols []corev1.Volume) []string {
+	out := make([]string, 0, len(vols))
+	for _, v := range vols {
+		out = append(out, v.Name)
+	}
+	return out
+}
+
+func volumeMountNames(vms []corev1.VolumeMount) []string {
+	out := make([]string, 0, len(vms))
+	for _, vm := range vms {
+		out = append(out, vm.Name)
+	}
+	return out
+}
+
+func sliceContains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
 }


### PR DESCRIPTION
Fixes #282.

## Problem

`MergeAgentWithTemplate` took the Agent's entire `podSpec` via `firstNonNilPtr`, so an Agent that set **any** `podSpec` field silently dropped **every** `podSpec` field defined in its `AgentTemplate` (common volumes, env, labels, scheduling, ...). Users could not attach common volumes from a template while also adding instance-specific volumes without re-declaring the template's volumes by hand in every Agent.

```go
// before: whole-struct replace
mergedPodSpec := firstNonNilPtr(agent.Spec.PodSpec, tmpl.Spec.PodSpec)
```

## Fix

Field-by-field deep merge via a new `mergePodSpec` helper:

| Field | Strategy |
|---|---|
| `Labels`, `Annotations` | maps combined; **Agent wins** on key conflict |
| `Scheduling.NodeSelector` | maps combined; Agent wins |
| `Scheduling.Tolerations` | appended (template first, then Agent) |
| `Scheduling.Affinity` | Agent if non-nil, else template |
| `ExtraVolumes`, `ExtraVolumeMounts`, `ExtraEnv` | slices combined, **deduped by Name**, Agent wins on collision |
| `SystemContainers.*` | each per-container-type override deep-merged (ExtraEnv + ExtraVolumeMounts combined, Agent wins on Name) |
| `RuntimeClassName`, `Resources`, `SecurityContext`, `PodSecurityContext`, `Lifecycle` | Agent wins if non-nil, else template |

Dedup-by-Name is important: without it, a template and an Agent that happen to use the same volume/env/mount name would produce a pod Kubernetes rejects (`Duplicate volume name` / `Duplicate env var name`). With dedup, Agent wins and the pod stays valid.

When only one side defines a `podSpec`, it is returned as-is (no allocation), preserving the previous behavior for the single-side case.

## Behavior change

This is an **intentional** semantic change for the both-set case: `replace` -> `merge`. Existing tests that encoded the old replace semantics (`TestMergeAgentWithTemplate_ExtraEnv_AgentWins`, `..._SystemContainers_AgentWins`) are updated to assert the merge (`..._DeepMerged`), and new tests cover each field's strategy (labels/annotations, volumes, volume mounts, scheduling, scalar pointers, nil cases).

## Scope

- No API/CRD changes (field structure unchanged, only merge semantics).
- Contained to `internal/controller/template_merge.go` + tests.
- `make build`, `make test`, `make lint` (0 issues), `make verify` all pass.

## Out of scope (other verdverm issues)

- #281 (OPENCODE_CONFIG_DIR) — needs API design for coexistence with skills/plugins.
- #283 (same shell / tmux) — CLI rewrite + RBAC/permission model change.