### PR TITLE
chore: release v0.1.9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,7 +382,7 @@ Three-tier strategy: unit (`make test`), integration (`make integration-test`, u
 
 ## Project Status
 
-- **Version**: v0.1.8
+- **Version**: v0.1.9
 - **API Stability**: v1alpha1 (subject to change)
 - **License**: MIT License
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: build
 .PHONY: all
 
 # Version information
-VERSION ?= v0.1.8
+VERSION ?= v0.1.9
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
 

--- a/agents/Makefile
+++ b/agents/Makefile
@@ -18,7 +18,7 @@ OPENCODE_VERSION ?= 1.17.11
 IMG_REGISTRY ?= ghcr.io
 IMG_ORG ?= kubeopencode
 IMG_NAME ?= kubeopencode-agent-$(AGENT)
-VERSION ?= v0.1.8
+VERSION ?= v0.1.9
 IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # Base image configuration

--- a/charts/kubeopencode/Chart.yaml
+++ b/charts/kubeopencode/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubeopencode
 description: A Kubernetes-native system for executing AI agent tasks across multiple repositories
 type: application
-version: 0.1.8
-appVersion: "v0.1.8"
+version: 0.1.9
+appVersion: "v0.1.9"
 keywords:
   - automation
   - ai-agent


### PR DESCRIPTION
Release preparation for v0.1.9.

## Changes

- Update VERSION to v0.1.9 in Makefile and agents/Makefile
- Update Chart.yaml version (0.1.9) and appVersion (v0.1.9)
- Update AGENTS.md project status version

## Release Highlights (since v0.1.8)

- **New Feature**: Added `podSpec.annotations` field to Agent and AgentTemplate (CRD change, backward-compatible)
- **Bug Fix**: Deep-merge podSpec across Agent and AgentTemplate (#286)
- **Bug Fix**: Preserve user gitconfig in agent pods (#285)
- **Chore**: Changed license from Apache 2.0 to MIT
- **Dependencies**: Bumped golang.org/x/net, debian base images, GitHub Actions

## CRD Change Notice

This release includes a CRD change (new optional `annotations` field in `AgentPodSpec`). `helm upgrade` does not update CRDs automatically. Please refer to the [Upgrade SOP](https://github.com/kubeopencode/kubeopencode/blob/main/docs/upgrading.md) for manual CRD update instructions.

Follows the Release SOP in `docs/releasing.md`.