### PR TITLE
feat: add --watch-namespaces to scope the manager cache

### DIFF
--- a/charts/kubeopencode/README.md
+++ b/charts/kubeopencode/README.md
@@ -95,6 +95,7 @@ The following table lists the configurable parameters of the KubeOpenCode chart 
 | `controller.image.tag` | Controller image tag | `""` (uses chart appVersion) |
 | `controller.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `controller.replicas` | Number of controller replicas | `1` |
+| `controller.watchNamespaces` | Namespaces the controller watches. Empty watches all namespaces and requires cluster-scoped RBAC | `[]` |
 | `controller.resources.limits.cpu` | CPU limit | `500m` |
 | `controller.resources.limits.memory` | Memory limit | `512Mi` |
 | `controller.resources.requests.cpu` | CPU request | `100m` |

--- a/charts/kubeopencode/templates/controller/deployment.yaml
+++ b/charts/kubeopencode/templates/controller/deployment.yaml
@@ -39,6 +39,9 @@ spec:
         - --leader-elect
         - --metrics-bind-address=:8080
         - --health-probe-bind-address=:8081
+        {{- with .Values.controller.watchNamespaces }}
+        - --watch-namespaces={{ join "," . }}
+        {{- end }}
         securityContext:
           {{- toYaml .Values.controller.securityContext | nindent 10 }}
         livenessProbe:

--- a/charts/kubeopencode/values.yaml
+++ b/charts/kubeopencode/values.yaml
@@ -14,6 +14,19 @@ controller:
   # Number of controller replicas (only 1 active with leader election)
   replicas: 1
 
+  # Namespaces the controller watches. Empty (the default) watches all
+  # namespaces, which requires the cluster-scoped RBAC this chart installs.
+  #
+  # Setting this restricts the manager cache to the listed namespaces, so the
+  # controller issues namespaced list/watch calls and no longer needs
+  # cluster-scoped read on cached types such as Secrets. Note that this chart
+  # still installs a ClusterRole; trimming that to namespaced Roles is a
+  # separate step you can take once the cache is scoped.
+  #
+  # watchNamespaces:
+  #   - kubeopencode-system
+  watchNamespaces: []
+
   # Resource limits and requests
   resources:
     limits:

--- a/cmd/kubeopencode/controller.go
+++ b/cmd/kubeopencode/controller.go
@@ -5,6 +5,7 @@ package main
 import (
 	"crypto/tls"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -12,6 +13,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -53,6 +55,7 @@ var (
 	enableLeaderElection bool
 	secureMetrics        bool
 	enableHTTP2          bool
+	watchNamespaces      []string
 )
 
 func init() {
@@ -67,6 +70,33 @@ func init() {
 		"If set the metrics endpoint is served securely")
 	controllerCmd.Flags().BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	controllerCmd.Flags().StringSliceVar(&watchNamespaces, "watch-namespaces", nil,
+		"Comma-separated list of namespaces to watch. When empty (the default) the "+
+			"controller watches all namespaces, which requires cluster-scoped list and "+
+			"watch permissions for every type it caches, including Secrets. When set, "+
+			"the cache issues namespaced list/watch calls instead, so the controller "+
+			"can run with namespaced Roles.")
+}
+
+// buildCacheOptions restricts the manager cache to the given namespaces.
+//
+// An empty or blank-only list yields the default all-namespace cache.
+// controller-runtime builds every informer at cluster scope in that mode, so the
+// controller needs cluster-scoped list and watch on each cached type. Naming
+// namespaces here switches those informers to namespaced calls, which a
+// RoleBinding can satisfy.
+func buildCacheOptions(namespaces []string) cache.Options {
+	byNamespace := make(map[string]cache.Config)
+	for _, ns := range namespaces {
+		if ns = strings.TrimSpace(ns); ns != "" {
+			byNamespace[ns] = cache.Config{}
+		}
+	}
+
+	if len(byNamespace) == 0 {
+		return cache.Options{}
+	}
+	return cache.Options{DefaultNamespaces: byNamespace}
 }
 
 func runController(cmd *cobra.Command, args []string) error {
@@ -95,8 +125,13 @@ func runController(cmd *cobra.Command, args []string) error {
 		TLSOpts: tlsOpts,
 	})
 
+	if len(watchNamespaces) > 0 {
+		setupLog.Info("restricting cache to namespaces", "namespaces", watchNamespaces)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
+		Cache:  buildCacheOptions(watchNamespaces),
 		Metrics: metricsserver.Options{
 			BindAddress:   metricsAddr,
 			SecureServing: secureMetrics,

--- a/cmd/kubeopencode/controller_test.go
+++ b/cmd/kubeopencode/controller_test.go
@@ -1,0 +1,83 @@
+// Copyright Contributors to the KubeOpenCode project
+
+package main
+
+import (
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+func TestBuildCacheOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespaces []string
+		want       map[string]cache.Config
+	}{
+		{
+			name:       "nil watches all namespaces",
+			namespaces: nil,
+			want:       nil,
+		},
+		{
+			name:       "empty slice watches all namespaces",
+			namespaces: []string{},
+			want:       nil,
+		},
+		{
+			name:       "blank entries are ignored and watch all namespaces",
+			namespaces: []string{"", "   "},
+			want:       nil,
+		},
+		{
+			name:       "single namespace",
+			namespaces: []string{"kubeopencode-system"},
+			want:       map[string]cache.Config{"kubeopencode-system": {}},
+		},
+		{
+			name:       "multiple namespaces",
+			namespaces: []string{"team-a", "team-b"},
+			want: map[string]cache.Config{
+				"team-a": {},
+				"team-b": {},
+			},
+		},
+		{
+			name:       "surrounding whitespace is trimmed",
+			namespaces: []string{" team-a ", "team-b"},
+			want: map[string]cache.Config{
+				"team-a": {},
+				"team-b": {},
+			},
+		},
+		{
+			name:       "duplicates collapse to one entry",
+			namespaces: []string{"team-a", "team-a"},
+			want:       map[string]cache.Config{"team-a": {}},
+		},
+		{
+			name:       "blank entries are dropped but real ones are kept",
+			namespaces: []string{"team-a", "", "team-b"},
+			want: map[string]cache.Config{
+				"team-a": {},
+				"team-b": {},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildCacheOptions(tt.namespaces).DefaultNamespaces
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("DefaultNamespaces has %d entries, want %d (got %v)",
+					len(got), len(tt.want), got)
+			}
+			for ns := range tt.want {
+				if _, ok := got[ns]; !ok {
+					t.Errorf("DefaultNamespaces is missing namespace %q (got %v)", ns, got)
+				}
+			}
+		})
+	}
+}

--- a/website/docs/security.md
+++ b/website/docs/security.md
@@ -15,6 +15,37 @@ KubeOpenCode follows the principle of least privilege:
 - **Controller**: ClusterRole with minimal permissions for Tasks, Agents, Pods, ConfigMaps, Secrets, and Events
 - **Agent ServiceAccount**: Namespace-scoped Role with read/update access to Tasks and read-only access to related resources
 
+### Restricting the controller to specific namespaces
+
+By default the controller watches every namespace. controller-runtime builds each
+informer at cluster scope in that mode, so the controller needs cluster-scoped
+`list` and `watch` on every type it caches — including Secrets. Per-namespace
+RoleBindings cannot satisfy a cluster-scoped watch, so trimming the ClusterRole
+alone makes the manager fail to start with `failed to wait for caches to sync`.
+
+Pass `--watch-namespaces` to scope the cache instead. The informers then issue
+namespaced calls, which a RoleBinding can satisfy:
+
+```bash
+kubeopencode controller --watch-namespaces=kubeopencode-system,team-a
+```
+
+Or through the chart:
+
+```yaml
+controller:
+  watchNamespaces:
+    - kubeopencode-system
+    - team-a
+```
+
+Tasks, Agents and CronTasks outside the listed namespaces are not reconciled, so
+list every namespace where those resources live.
+
+The chart still installs a ClusterRole. Scoping the cache is what makes narrower
+RBAC *possible*; replacing the ClusterRole with per-namespace Roles is a separate
+step you can take once `--watch-namespaces` is set.
+
 ### Web UI User Permissions
 
 The Helm chart includes a `kubeopencode-web-user` ClusterRole with all permissions needed to use the web dashboard. Bind it per namespace to grant team access:


### PR DESCRIPTION
## Summary

Adds an optional `--watch-namespaces` flag that restricts the manager cache to a
list of namespaces, so the controller can run without cluster-scoped `list`/`watch`
on the types it caches.

By default the controller watches every namespace. controller-runtime builds each
informer at cluster scope in that mode, so the controller needs cluster-scoped
`list` and `watch` on every cached type — including Secrets.

That requirement is easy to miss until someone tries to reduce it. Moving the
controller's Secret access to a namespaced Role looks reasonable and leaves the
manager unable to start: a RoleBinding cannot satisfy a cluster-scoped watch, so
startup fails with

```
failed to wait for caches to sync
```

naming whichever informer timed out first, which is often not the one that lost
permission. The underlying `Failed to watch *v1.Secret ... forbidden ... at the
cluster scope` line is logged separately and is easy to overlook.

With `--watch-namespaces` set, the informers issue namespaced calls that a
RoleBinding can satisfy:

```bash
kubeopencode controller --watch-namespaces=kubeopencode-system,team-a
```

or via the chart:

```yaml
controller:
  watchNamespaces:
    - kubeopencode-system
    - team-a
```

**The default is unchanged.** An empty list produces exactly today's
all-namespace cache.

### What's included

- `--watch-namespaces` flag and `buildCacheOptions`, which trims blanks and
  de-duplicates
- `controller.watchNamespaces` in the chart, so the flag is reachable from a Helm
  install (args are currently hardcoded in the deployment template, with no
  `extraArgs` escape hatch)
- A note in `website/docs/security.md` explaining that scoping the cache is what
  makes narrower RBAC *possible*, and that Tasks/Agents/CronTasks outside the
  listed namespaces will not be reconciled

### Deliberately not included

The chart still installs a ClusterRole. Replacing it with per-namespace Roles is a
larger change and a separate decision; this PR makes it possible rather than making
it for you. Happy to follow up with that if you'd like it.

## Related Issues

No existing issue — I searched open and closed issues and PRs for namespace,
RBAC, cache and cluster-scope and found nothing covering this. Happy to open one
first if you prefer that order.

## Test Plan

- [x] Unit tests pass — table-driven `TestBuildCacheOptions` covering nil, empty,
      blank-only, single, multiple, whitespace-trimmed, duplicate and mixed input
- [x] `go build ./...`, `go vet ./cmd/...` and `gofmt -l` clean on Go 1.26
- [x] `helm lint` passes; `helm template` verified to emit no flag by default and
      `--watch-namespaces=kubeopencode-system,team-a` when the value is set
- [x] `controller --help` shows the flag
- [ ] Integration / E2E — not run locally

One note while I was here: `make test` runs `go test ./internal/...`, so nothing
under `cmd/` is covered by CI, including the three test files already there
(`task_submit_test.go`, `git_init_ca_test.go`, `url_fetch_ca_test.go`) and the one
this PR adds. I left the new test alongside the existing ones rather than change
your test target in a feature PR, but it does mean it won't run in CI as things
stand. Widening `make test` would need `make ui-build` first, since `ui/embed.go`
embeds `dist/*`. Glad to send that as its own PR if useful.